### PR TITLE
Change name from cluttex_teal to cluttealtex

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -32,20 +32,20 @@ jobs:
 
     - name: move artifacts
       run: |
-          mv build/doc/cluttex_teal.pdf ./
-          mv bin/cluttex_teal* ./
+          mv build/doc/cluttealtex.pdf ./
+          mv bin/cluttealtex* ./
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4.3.1
       with:
         name: doc
         path: |
-          cluttex_teal.pdf
+          cluttealtex.pdf
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4.3.1
       with:
         name: binaries
         path: |
-          cluttex_teal
-          cluttex_teal.bat
+          cluttealtex
+          cluttealtex.bat

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,6 @@ jobs:
 
     - uses: ncipollo/release-action@v1
       with:
-        artifacts: "build/doc/cluttex_teal.pdf,bin/cluttex_teal*"
+        artifacts: "build/doc/cluttealtex.pdf,bin/cluttealtex*"
         artifactErrorsFailBuild: true
         generateReleaseNotes: true

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ all: build doc install
 
 build: checkAll
 	eval $$(luarocks path) && tl build
-	sed -i '1s;^;#!/usr/bin/env texlua\n;' src_lua/cluttex_teal.lua
+	sed -i '1s;^;#!/usr/bin/env texlua\n;' src_lua/cluttealtex.lua
 	cp src_teal/texrunner/*lua src_lua/texrunner/
 	cp src_teal/os_.lua src_lua/
-	make -f Makefile.cluttex_teal
+	make -f Makefile.cluttealtex
 
 doc:
 	l3build doc

--- a/Makefile.cluttealtex
+++ b/Makefile.cluttealtex
@@ -1,4 +1,4 @@
-all: bin/cluttex_teal bin/cluttex_teal.bat
+all: bin/cluttealtex bin/cluttealtex.bat
 
 .PHONY: all archive check-version
 
@@ -22,24 +22,24 @@ sources= \
 		 src_lua/texrunner/fswatcher_windows.lua \
 		 src_lua/texrunner/safename.lua \
 		 src_lua/texrunner/checkdriver.lua \
-		 src_lua/cluttex_teal.lua
+		 src_lua/cluttealtex.lua
 
-bin/cluttex_teal: $(sources) utils/build_cluttex_teal.lua
+bin/cluttealtex: $(sources) utils/build_cluttealtex.lua
 	@mkdir -p bin
-	lua utils/build_cluttex_teal.lua --unix-shellscript $@
+	lua utils/build_cluttealtex.lua --unix-shellscript $@
 	lua utils/checkglobal.lua $@
 	chmod +x $@
 
-bin/cluttex_teal.bat: $(sources) utils/build_cluttex_teal.lua
+bin/cluttealtex.bat: $(sources) utils/build_cluttealtex.lua
 	@mkdir -p bin
-	lua utils/build_cluttex_teal.lua --windows-batchfile $@
+	lua utils/build_cluttealtex.lua --windows-batchfile $@
 	lua utils/checkglobal.lua $@
 
-version_file=$(shell bin/cluttex_teal --version 2>&1 | grep --only-matching -E 'v\d+(\.\d+)*' | sed 's/^v/VERSION_/;s/\./_/g')
+version_file=$(shell bin/cluttealtex --version 2>&1 | grep --only-matching -E 'v\d+(\.\d+)*' | sed 's/^v/VERSION_/;s/\./_/g')
 
 check-version: all
-	@bin/cluttex_teal --version
-	grep VERSION src_lua/cluttex_teal.lua
-	grep VERSION bin/cluttex_teal
-	grep VERSION bin/cluttex_teal.bat
-	grep -i VERSION doc/cluttex_teal.tex
+	@bin/cluttealtex --version
+	grep VERSION src_lua/cluttealtex.lua
+	grep VERSION bin/cluttealtex
+	grep VERSION bin/cluttealtex.bat
+	grep -i VERSION doc/cluttealtex.tex

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 **Note: This is a fork of [cluttex](https://github.com/minoki/cluttex) which is
 using teal to transpile typed lua to classic lua.**
 
-# cluttex_teal
+# clutealtex
 
 See `-h` and/or the documentation in `pdf` format.
 
 ## Features
-- written in /generated with teal/tl => no external dependencies, lua should be
-  included in texlive.
+- written in / generated with teal/tl => no external dependencies, (tex)lua should
+  be included in texlive.
 - avoid cluttering your project directory with aux files
 - watch input files and automatically rebuild on change
 - run `makindex`, BibTeX, `biber` if requested
 - configure manual glossaries with the `--glossaries` option
 - also supports the `memoize` package. You only need to pass `--memoize` to
-  `cluttex_teal` and put `\usepackage{memoize}` in your LaTeX file. Also you can
+  `cluttealtex` and put `\usepackage{memoize}` in your LaTeX file. Also you can
   pass arbitrary additional parameters to `memoize` (useful for e.g. `readonly` key)

--- a/build.lua
+++ b/build.lua
@@ -1,4 +1,4 @@
-module = "cluttex_teal"
+module = "cluttealtex"
 typesetexe = "lualatex"
 typesetfiles = {"*.tex"}
 
@@ -6,7 +6,7 @@ unpackexe  = "luatex"
 unpackfiles = {}
 docfiledir = "./doc"
 
-scriptfiles = {"cluttex_teal", "cluttex_teal.bat"}
-sourcefiles = {"bin/cluttex_teal", "bin/cluttex_teal.bat"}
+scriptfiles = {"cluttealtex", "cluttealtex.bat"}
+sourcefiles = {"bin/cluttealtex", "bin/cluttealtex.bat"}
 
 excludefiles = {".link.md", "*~", "build.lua"}

--- a/doc/cluttealtex.tex
+++ b/doc/cluttealtex.tex
@@ -2,23 +2,25 @@
 \usepackage[unicode]{hyperref}
 \usepackage{amsmath}
 \usepackage{tabularx}
-\newcommand\ClutTeX{Clut\TeX\_teal}
-\providecommand\BibTeX{\textsc{Bib}\TeX}
+\usepackage{xspace}
+\usepackage{csquotes}
+\newcommand\CluttealTeX{Clutteal\TeX\xspace}
+\providecommand\BibTeX{\textsc{Bib}\TeX\xspace}
 \newcommand\texcmd[1]{\texttt{\textbackslash #1}}
 \newcommand\texenv[1]{\texttt{#1}}
 \newcommand\texpkg[1]{\texttt{#1}}
 \newcommand\metavar[1]{\textnormal{\textsf{#1}}}
 
-\title{\ClutTeX\ manual\\(Version 0.7.1)}
-\author{Lukas Heindl\thanks{thanks to ARATA Mizuki for writing cluttex of which \ClutTeX{} is a fork}}
+\title{\CluttealTeX manual\\(Version 0.7.1)}
+\author{Lukas Heindl\thanks{thanks to ARATA Mizuki for writing cluttex of which \CluttealTeX is a fork}}
 \date{2024-03-11}
 
 \begin{document}
 \maketitle
 \tableofcontents
 
-\chapter{About \ClutTeX}
-\ClutTeX\ is an automation tool for \LaTeX\ document processing.
+\chapter{About \CluttealTeX}
+\CluttealTeX is an automation tool for \LaTeX\ document processing.
 Basic features are,
 \begin{itemize}
 \item Does not clutter your working directory with ``extra'' files, like \texttt{.aux} or \texttt{.log}.
@@ -27,19 +29,19 @@ Basic features are,
 \item Run MakeIndex, \BibTeX, Biber, if requested.
 \item Produces a PDF, even if the engine (e.g.\ p\TeX) does not suport direct PDF generation.
   If you want a DVI file, use \texttt{--output-format=dvi} option.
-\item No external dependencies, \ClutTeX only uses texlua which should come with TeXLive
+\item No external dependencies, \CluttealTeX only uses texlua which should come with TeXLive
 \end{itemize}
 
 The unique feature of this program is that, auxiliary files such as \texttt{.aux} or \texttt{.toc} are created in an isolated location, so you will not be annoyed with these extra files.
 
 % A competitor: \href{http://www.personal.psu.edu/jcc8/latexmk/}{Latexmk}
 
-\chapter{How to use \ClutTeX}
+\chapter{How to use \CluttealTeX}
 \section{Installation}
-If you want to install \ClutTeX\ manually, fetch an archive from
-GitHub\footnote{\url{https://github.com/atticus-sullivan/cluttex_teal}} (either
+If you want to install \CluttealTeX manually, fetch an archive from
+GitHub\footnote{\url{https://github.com/atticus-sullivan/cluttealtex}} (either
 release for stable builds or from github actions for nightly build), extract
-it, and copy \texttt{bin/cluttex\_teal} or \texttt{bin/cluttex\_teal.bat} to
+it, and copy \texttt{bin/cluttealtex} or \texttt{bin/cluttealtex.bat} to
 somewhere in your \texttt{PATH}.
 
 \subsection{Building}
@@ -50,7 +52,7 @@ required tools \texttt{fd}, \texttt{tl} (luarocks)) for installing to your
 \section{Command-line usage}
 Usage:
 \begin{center}
-  \texttt{cluttex\_teal -e \metavar{ENGINE} \metavar{OPTIONs} [--] \metavar{INPUT}.tex}
+  \texttt{cluttealtex -e \metavar{ENGINE} \metavar{OPTIONs} [--] \metavar{INPUT}.tex}
 \end{center}
 
 \subsection{Basic options}
@@ -126,9 +128,9 @@ Usage:
   Enable the hook for running an extract script or for the memoize package. Set
   either to \texttt{python} or \texttt{perl} (default) to select which
   extraction script to run or directly specify the executable which shall be
-  run. This will also set the key \texttt{no memo dir} as cluttex\_teal itself
+  run. This will also set the key \texttt{no memo dir} as cluttealtex itself
   already provides the feature of avoiding to clutter the working directory. It
-  also sets the key \texttt{extract=no} since cluttex\_teal performs the
+  also sets the key \texttt{extract=no} since cluttealtex performs the
   extraction on its own.
 \item[\texttt{--memoize\_opts=\metavar{PACKAGE OPT}}]
   Pass additional options like \texttt{readonly} to the memoize package. Pass
@@ -172,11 +174,11 @@ Combining multiple short options, like \texttt{-Ve pdflatex}, is not supported.
 \section{Sync\TeX}\label{sec:synctex}
 You can generate Sync\TeX\ data with \texttt{--synctex=1} option.
 
-Although \ClutTeX\ has ``Don't clutter your working directory'' as its motto, the \texttt{.synctex.gz} file is always produced alongside the PDF file.
+Although \CluttealTeX\ has \enquote{Don't clutter your working directory} as its motto, the \texttt{.synctex.gz} file is always produced alongside the PDF file.
 This is because Sync\TeX\ cannot find its data file if it's not in the same directory as the PDF.
 
 \section{Watch mode}\label{sec:watch-mode}
-If \texttt{--watch} option is given, \ClutTeX\ enters \emph{watch mode} after processing the document.
+If \texttt{--watch} option is given, \CluttealTeX\ enters \emph{watch mode} after processing the document.
 
 On Windows, a built-in filesystem watcher is implemented.
 
@@ -248,37 +250,37 @@ When doing so, \texcmd{includeonly} can be used to eliminate processing time.
 But writing \texcmd{includeonly} in the \TeX\ source file is somewhat inconvenient.
 After all, \texcmd{includeonly} is about \emph{how} to process the document, not about its content.
 
-Therefore, \ClutTeX\ provides an command-line option to use \texcmd{includeonly}.
+Therefore, \CluttealTeX\ provides an command-line option to use \texcmd{includeonly}.
 See \autoref{sec:makefile-example} for example.
 
 Tips: When using \texttt{includeonly}, avoid using \texttt{--makeindex} or \texttt{--biber}.
 
 Another technique for eliminating time is, setting \texttt{--max-iterations=1}.
-It stops \ClutTeX\ from processing the document multiple times, which may take several extra minutes.
+It stops \CluttealTeX\ from processing the document multiple times, which may take several extra minutes.
 
 \section{Using Makefile}\label{sec:makefile-example}
-You can create Makefile to avoid writing \ClutTeX\ options each time.
+You can create Makefile to avoid writing \CluttealTeX\ options each time.
 Example:
 \begin{verbatim}
 main.pdf: main.tex chap1.tex chap2.tex
-    cluttex_teal -e lualatex -o $@ --makeindex=mendex $<
+    cluttealtex -e lualatex -o $@ --makeindex=mendex $<
 
 main-preview.pdf: main.tex chap1.tex chap2.tex
-    cluttex_teal -e lualatex -o $@ --makeindex=mendex --max-iterations=1 $<
+    cluttealtex -e lualatex -o $@ --makeindex=mendex --max-iterations=1 $<
 
 chap1-preview.pdf: main.tex chap1.tex
-    cluttex_teal -e lualatex -o $@ --max-iterations=1 --includeonly=chap1 $<
+    cluttealtex -e lualatex -o $@ --max-iterations=1 --includeonly=chap1 $<
 
 chap2-preview.pdf: main.tex chap2.tex
-    cluttex_teal -e lualatex -o $@ --max-iterations=1 --includeonly=chap2 $<
+    cluttealtex -e lualatex -o $@ --max-iterations=1 --includeonly=chap2 $<
 \end{verbatim}
 
-With \texttt{--make-depends} option, you can let \ClutTeX\ infer sub-files and omit them from Makefile.
+With \texttt{--make-depends} option, you can let \CluttealTeX\ infer sub-files and omit them from Makefile.
 Example:
 
 \begin{verbatim}
 main.pdf: main.tex
-    cluttex_teal -e lualatex -o $@ --make-depends=main.pdf.dep $<
+    cluttealtex -e lualatex -o $@ --make-depends=main.pdf.dep $<
 
 -include main.pdf.dep
 \end{verbatim}
@@ -304,34 +306,34 @@ On the other hand, the following parameters doesn't affect the directory name:
 \item \texttt{--makeindex}, \texttt{--bibtex}, \texttt{--biber}, \texttt{--glossaries}
 \end{itemize}
 
-If you need to know the exact location of the automatically-generated output directory, you can invoke \ClutTeX\ with \texttt{--print-output-directory}.
+If you need to know the exact location of the automatically-generated output directory, you can invoke \CluttealTeX with \texttt{--print-output-directory}.
 For example, \texttt{clean} target of your Makefile could be written as:
 \begin{verbatim}
 clean:
-    -rm -rf $(shell cluttex_teal -e pdflatex --print-output-directory main.tex)
+    -rm -rf $(shell cluttealtex -e pdflatex --print-output-directory main.tex)
 \end{verbatim}
 
-\ClutTeX\ itself doesn't erase the auxiliary files, unless \texttt{--fresh} option is set.
+\CluttealTeX itself doesn't erase the auxiliary files, unless \texttt{--fresh} option is set.
 Note that, the use of a temporary directory means, the auxiliary files may be cleared when the computer is rebooted.
 
 \section{Support for \texpkg{minted} and \texpkg{epstopdf}}
 In general, packages that execute external commands (shell-escape) don't work well with \texttt{-output-directory}.
-Therefore, they don't work well with \ClutTeX.
+Therefore, they don't work well with \CluttealTeX.
 
 However, some packages provide a package option to let them know the location of \texttt{-output-directory}.
 For example, \texpkg{minted} provides \texttt{outputdir}, and \texpkg{epstopdf} provides \texttt{outdir}.
 
-\ClutTeX\ can supply them the appropriate options, but only if it knows that the package is going to be used.
-To let \ClutTeX\ what packages are going to be used, use \texttt{--package-support} option.
+\CluttealTeX\ can supply them the appropriate options, but only if it knows that the package is going to be used.
+To let \CluttealTeX\ what packages are going to be used, use \texttt{--package-support} option.
 
 For example, if you want to typeset a document that uses \texpkg{minted}, run the following:
 \begin{verbatim}
-cluttex_teal -e pdflatex --shell-escape --package-support=minted document.tex
+cluttealtex -e pdflatex --shell-escape --package-support=minted document.tex
 \end{verbatim}
 
 \section{Check for driver file}
 
-\ClutTeX\ can check that the correct driver file is loaded when certain packages are loaded.
+\CluttealTeX\ can check that the correct driver file is loaded when certain packages are loaded.
 Currently, the list of supported packages are \texpkg{graphics}, \texpkg{color}, \texpkg{expl3}, \texpkg{hyperref}, and \texpkg{xy}.
 
 The check is always done with PDF mode.

--- a/doc/cluttealtex.tex
+++ b/doc/cluttealtex.tex
@@ -4,7 +4,7 @@
 \usepackage{tabularx}
 \usepackage{xspace}
 \usepackage{csquotes}
-\newcommand\CluttealTeX{Clutteal\TeX\xspace}
+\newcommand\CluttealTeX{ClutTeal\TeX\xspace}
 \providecommand\BibTeX{\textsc{Bib}\TeX\xspace}
 \newcommand\texcmd[1]{\texttt{\textbackslash #1}}
 \newcommand\texenv[1]{\texttt{#1}}

--- a/src_teal/cluttealtex.tl
+++ b/src_teal/cluttealtex.tl
@@ -3,23 +3,23 @@
   Copyright 2016-2021 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
-global CLUTTEX_VERSION: string = "v0.7.1"
+global CLUTTEALTEX_VERSION: string = "v0.7.1"
 
 -- Standard libraries
 local table = table
@@ -45,7 +45,7 @@ local recoverylib = require "texrunner.recovery"
 local message     = require "texrunner.message"
 local safename    = require "texrunner.safename"
 local extract_bibtex_from_aux_file = require "texrunner.auxfile".extract_bibtex_from_aux_file
-local handle_cluttex_options = require "texrunner.handleoption".handle_cluttex_options
+local handle_cluttealtex_options = require "texrunner.handleoption".handle_cluttealtex_options
 local checkdriver = require "texrunner.checkdriver".checkdriver
 local engine_t = require "texrunner.tex_engine"
 local fswatcherlib_t = require"texrunner.fswatcher"
@@ -65,7 +65,7 @@ local function genOutputDirectory(...: string): string
 	return pathutil.join(tmpdir, 'latex-build-' .. hash)
 end
 
-local inputfile, engine, options = handle_cluttex_options(arg)
+local inputfile, engine, options = handle_cluttealtex_options(arg)
 
 local jobname_for_output: string
 if options.jobname == nil then
@@ -100,7 +100,7 @@ if options.output_directory == nil then
 	elseif options.fresh then
 		-- The output directory exists and --fresh is given:
 		-- Remove all files in the output directory
-		if CLUTTEX_VERBOSITY >= 1 then
+		if CLUTTEALTEX_VERBOSITY >= 1 then
 			message.info("Cleaning '", options.output_directory, "'...")
 		end
 		assert(fsutil.remove_rec(options.output_directory))
@@ -161,7 +161,7 @@ local function path_in_output_directory(ext:string): string
 end
 
 local recorderfile = path_in_output_directory("fls")
-local recorderfile2 = path_in_output_directory("cluttex-fls")
+local recorderfile2 = path_in_output_directory("cluttealtex-fls")
 
 local tex_options:engine_t.Option = {
 	engine_executable = options.engine_executable,
@@ -182,7 +182,7 @@ end
 
 -- Setup LuaTeX initialization script
 if engine.is_luatex then
-	local initscriptfile = path_in_output_directory("cluttexinit.lua")
+	local initscriptfile = path_in_output_directory("cluttealtexinit.lua")
 	luatexinit.create_initialization_script(initscriptfile, tex_options)
 	tex_options.lua_initialization_script = initscriptfile
 end
@@ -396,7 +396,7 @@ local function single_run(auxstatus:{string:reruncheck.Status}, iteration:intege
 			}
 			coroutine.yield(table.concat(bibtex_command, " "))
 		else
-			if CLUTTEX_VERBOSITY >= 1 then
+			if CLUTTEALTEX_VERBOSITY >= 1 then
 				message.info("No need to run BibTeX.")
 			end
 			local succ, err = filesys.touch(output_bbl)
@@ -631,7 +631,7 @@ local function do_typeset(): boolean, string, integer
 		end
 	end
 	-- Successful
-	if CLUTTEX_VERBOSITY >= 1 then
+	if CLUTTEALTEX_VERBOSITY >= 1 then
 		message.info("Command exited successfully")
 	end
 	return true
@@ -644,7 +644,7 @@ if options.watch then
 	if os.type == "windows" then
 		-- Windows: Try built-in filesystem watcher
 		local succ, result = pcall(require, "texrunner.fswatcher_windows")
-		if not succ and CLUTTEX_VERBOSITY >= 1 then
+		if not succ and CLUTTEALTEX_VERBOSITY >= 1 then
 			message.warn("Failed to load texrunner.fswatcher_windows: " .. result as string)
 		end
 		fswatcherlib = result
@@ -652,7 +652,7 @@ if options.watch then
 
 	local do_watch: function({string}):boolean
 	if fswatcherlib then
-		if CLUTTEX_VERBOSITY >= 2 then
+		if CLUTTEALTEX_VERBOSITY >= 2 then
 			message.info("Using built-in filesystem watcher for Windows")
 		end
 		do_watch = function(files:{string}): boolean
@@ -661,14 +661,14 @@ if options.watch then
 				assert(watcher:add_file(path))
 			end
 			local result = assert(watcher:next())
-			if CLUTTEX_VERBOSITY >= 2 then
+			if CLUTTEALTEX_VERBOSITY >= 2 then
 				message.info(string.format("%s %s", result.action, result.path))
 			end
 			watcher:close()
 			return true
 		end
 	elseif (options.watch == "auto" or options.watch == "fswatch") and shellutil.has_command("fswatch") then
-		if CLUTTEX_VERBOSITY >= 2 then
+		if CLUTTEALTEX_VERBOSITY >= 2 then
 			message.info("Using `fswatch' command")
 		end
 		do_watch = function(files:{string}): boolean
@@ -677,7 +677,7 @@ if options.watch then
 				table.insert(fswatch_command, shellutil.escape(path))
 			end
 			local fswatch_command_str = table.concat(fswatch_command, " ")
-			if CLUTTEX_VERBOSITY >= 1 then
+			if CLUTTEALTEX_VERBOSITY >= 1 then
 				message.exec(fswatch_command_str)
 			end
 			local fswatch = assert(io.popen(fswatch_command_str, "r"))
@@ -692,7 +692,7 @@ if options.watch then
 			return false
 		end
 	elseif (options.watch == "auto" or options.watch == "inotifywait") and shellutil.has_command("inotifywait") then
-		if CLUTTEX_VERBOSITY >= 2 then
+		if CLUTTEALTEX_VERBOSITY >= 2 then
 			message.info("Using `inotifywait' command")
 		end
 		do_watch = function(files:{string}): boolean
@@ -701,7 +701,7 @@ if options.watch then
 				table.insert(inotifywait_command, shellutil.escape(path))
 			end
 			local inotifywait_command_str = table.concat(inotifywait_command, " ")
-			if CLUTTEX_VERBOSITY >= 1 then
+			if CLUTTEALTEX_VERBOSITY >= 1 then
 				message.exec(inotifywait_command_str)
 			end
 			local inotifywait = assert(io.popen(inotifywait_command_str, "r"))
@@ -723,7 +723,7 @@ if options.watch then
 		elseif options.watch == "inotifywait" then
 			message.error("Could not watch files because your selected engine `inotifywait' was not installed.")
 		end
-		message.info("See ClutTeX_teal's manual for details.")
+		message.info("See CluttealTeX's manual for details.")
 		os.exit(1)
 	end
 

--- a/src_teal/texrunner/auxfile.tl
+++ b/src_teal/texrunner/auxfile.tl
@@ -2,20 +2,20 @@
 Copyright 2016 ARATA Mizuki
 Copyright 2024 Lukas Heindl
 
-This file is part of ClutTeX_teal.
+This file is part of CluttealTeX.
 
-ClutTeX_teal is free software: you can redistribute it and/or modify
+CluttealTeX is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-ClutTeX_teal is distributed in the hope that it will be useful,
+CluttealTeX is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local string_match = string.match

--- a/src_teal/texrunner/auxfile.tl
+++ b/src_teal/texrunner/auxfile.tl
@@ -57,7 +57,7 @@ local function extract_bibtex_from_aux_file(auxfile:string, outdir:string, bibli
 		local name = string_match(l, "\\([%a@]+)")
 		if name == "citation" or name == "bibdata" or name == "bibstyle" then
 			table.insert(biblines, l)
-			if CLUTTEX_VERBOSITY >= 2 then
+			if CLUTTEALTEX_VERBOSITY >= 2 then
 				message.info("BibTeX line: ", l)
 			end
 			elseif name == "@input" then

--- a/src_teal/texrunner/checkdriver.tl
+++ b/src_teal/texrunner/checkdriver.tl
@@ -2,20 +2,20 @@
   Copyright 2020 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 local assert = assert
 local ipairs = ipairs

--- a/src_teal/texrunner/checkdriver.tl
+++ b/src_teal/texrunner/checkdriver.tl
@@ -91,7 +91,7 @@ local right_values:{string:Values} = {
 
 -- expected_driver: one of "dvips", "dvipdfmx", "dvisvgm", "pdftex", "xetex", "luatex"
 local function checkdriver(expected_driver:string, filelist:{reruncheck.Filemap_ele})
-	if CLUTTEX_VERBOSITY >= 1 then
+	if CLUTTEALTEX_VERBOSITY >= 1 then
 		message.info("checkdriver: expects ", expected_driver)
 	end
 
@@ -176,7 +176,7 @@ local function checkdriver(expected_driver:string, filelist:{reruncheck.Filemap_
 		-- TODO: dvisvgm?
 	end
 
-	if CLUTTEX_VERBOSITY >= 1 then
+	if CLUTTEALTEX_VERBOSITY >= 1 then
 		message.info("checkdriver: graphics=", tostring(graphics_driver))
 		message.info("checkdriver: expl3=", tostring(expl3_driver))
 		message.info("checkdriver: hyperref=", tostring(hyperref_driver))

--- a/src_teal/texrunner/fsutil.tl
+++ b/src_teal/texrunner/fsutil.tl
@@ -2,20 +2,20 @@
   Copyright 2016 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local os = require "os_"

--- a/src_teal/texrunner/fswatcher_windows.lua
+++ b/src_teal/texrunner/fswatcher_windows.lua
@@ -2,20 +2,20 @@
   Copyright 2019 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local ffi = require "ffi"

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -25,11 +25,11 @@ local options = require"texrunner.option_type"
 
 local record Module
 	usage: function({string})
-	handle_cluttex_options: function({string}): string,TexEngine.Engine,options.Options
+	handle_cluttealtex_options: function({string}): string,TexEngine.Engine,options.Options
 end
 
 local KnownEngines = TexEngine.KnownEngines
-global CLUTTEX_VERSION:string
+global CLUTTEALTEX_VERSION:string
 
 local function split(opt:string): {string}
 	local ret,builder,state = {},{},0
@@ -111,7 +111,7 @@ end
 
 local function usage(arg:{string})
 	io.write(string.format([[
-ClutTeX_teal: Process TeX files without cluttering your working directory
+ClutteakTeX: Process TeX files without cluttering your working directory
 
 Usage:
   %s [options] [--] FILE.tex
@@ -168,7 +168,7 @@ Options:
   -h, --help                   Print this message and exit.
   -v, --version                Print version information and exit.
   -V, --verbose                Be more verbose.
-      --color[=WHEN]           Make ClutTeX_teal's message colorful. WHEN is one of
+      --color[=WHEN]           Make CluttealTeX's message colorful. WHEN is one of
                                  `always', `auto', or `never'.
                                  [default: `auto' if --color is omitted,
                                            `always' if WHEN is omitted]
@@ -194,11 +194,11 @@ Options:
       --output-format=FORMAT   FORMAT is `pdf' or `dvi'.  [default: pdf]
 
 %s
-]], arg[0] or 'texlua cluttex_teal.lua', COPYRIGHT_NOTICE))
+]], arg[0] or 'texlua cluttealtex.lua', COPYRIGHT_NOTICE))
 end
 
 local option_spec = {
-	-- Options for ClutTeX_teal
+	-- Options for CluttealTeX
 	{
 		short = "e",
 		long = "engine",
@@ -394,8 +394,8 @@ local function set_default_values(options:options.Options)
 	end
 end
 
--- inputfile, engine, options = handle_cluttex_options(arg)
-local function handle_cluttex_options(arg:{string}): string,TexEngine.Engine,options.Options
+-- inputfile, engine, options = handle_cluttealtex_options(arg)
+local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine,options.Options
 	-- Parse options
 	local option_and_params, non_option_index = parseoption(arg, option_spec)
 
@@ -405,7 +405,7 @@ local function handle_cluttex_options(arg:{string}): string,TexEngine.Engine,opt
 		dvipdfmx_extraoptions = {},
 		package_support = {},
 	}
-	CLUTTEX_VERBOSITY = 0
+	CLUTTEALTEX_VERBOSITY = 0
 	for _,option in ipairs(option_and_params) do
 		local name:string = option[1]
 		local param:string|boolean = option[2]
@@ -464,11 +464,11 @@ local function handle_cluttex_options(arg:{string}): string,TexEngine.Engine,opt
 			os.exit(0)
 
 		elseif name == "version" then
-			io.stderr:write("cluttex_teal ",CLUTTEX_VERSION,"\n")
+			io.stderr:write("cluttealtex ",CLUTTEALTEX_VERSION,"\n")
 			os.exit(0)
 
 		elseif name == "verbose" then
-			CLUTTEX_VERBOSITY = CLUTTEX_VERBOSITY + 1
+			CLUTTEALTEX_VERBOSITY = CLUTTEALTEX_VERBOSITY + 1
 
 		elseif name == "color" then
 			assert(options.color == nil, "multiple --color options")
@@ -516,8 +516,8 @@ local function handle_cluttex_options(arg:{string}): string,TexEngine.Engine,opt
 			if param is string then
 				for pkg in string.gmatch(param, "[^,%s]+") do
 					options.package_support[pkg] = true
-					if not known_packages[pkg] and CLUTTEX_VERBOSITY >= 1 then
-						message.warn("ClutTeX_teal provides no special support for '"..pkg.."'.")
+					if not known_packages[pkg] and CLUTTEALTEX_VERBOSITY >= 1 then
+						message.warn("CluttealTeX provides no special support for '"..pkg.."'.")
 					end
 				end
 			else
@@ -772,7 +772,7 @@ local function handle_cluttex_options(arg:{string}): string,TexEngine.Engine,opt
 				message.warn("Driver check will not work.")
 			end
 		else
-			-- ClutTeX_teal uses dvipdfmx to generate PDF from DVI output.
+			-- CluttealTeX uses dvipdfmx to generate PDF from DVI output.
 			options.check_driver = "dvipdfmx"
 		end
 	end
@@ -782,6 +782,6 @@ end
 
 local _M:Module = {
 	usage = usage,
-	handle_cluttex_options = handle_cluttex_options,
+	handle_cluttealtex_options = handle_cluttealtex_options,
 }
 return _M

--- a/src_teal/texrunner/isatty.lua
+++ b/src_teal/texrunner/isatty.lua
@@ -37,12 +37,12 @@ int fileno(void *stream);
       }
   end)
   if succ then
-    if CLUTTEX_VERBOSITY >= 3 then
+    if CLUTTEALTEX_VERBOSITY >= 3 then
       io.stderr:write("CluttealTeX: isatty found via FFI (Unix)\n")
     end
     return M
   else
-    if CLUTTEX_VERBOSITY >= 3 then
+    if CLUTTEALTEX_VERBOSITY >= 3 then
       io.stderr:write("CluttealTeX: FFI (Unix) not found: ", M, "\n")
     end
   end
@@ -58,12 +58,12 @@ int fileno(void *stream);
       }
   end)
   if succ then
-    if CLUTTEX_VERBOSITY >= 3 then
+    if CLUTTEALTEX_VERBOSITY >= 3 then
       io.stderr:write("CluttealTeX: isatty found via luaposix\n")
     end
     return M
   else
-    if CLUTTEX_VERBOSITY >= 3 then
+    if CLUTTEALTEX_VERBOSITY >= 3 then
       io.stderr:write("CluttealTeX: luaposix not found: ", M, "\n")
     end
   end
@@ -128,7 +128,7 @@ DWORD GetLastError();
         local filetype = GetFileType(handle)
         if filetype ~= 0x0003 then -- not FILE_TYPE_PIPE (0x0003)
           -- mintty must be a pipe
-          if CLUTTEX_VERBOSITY >= 4 then
+          if CLUTTEALTEX_VERBOSITY >= 4 then
             io.stderr:write("CluttealTeX: is_mintty: not a pipe\n")
           end
           return false
@@ -138,13 +138,13 @@ DWORD GetLastError();
         if GetFileInformationByHandleEx(handle, FileNameInfo, nameinfo, ffi.sizeof("FILE_NAME_INFO", 32768)) ~= 0 then
           local filename = wide_to_narrow(nameinfo.FileName, math.floor(nameinfo.FileNameLength / 2))
           -- \(cygwin|msys)-<hex digits>-pty<N>-(from|to)-master
-          if CLUTTEX_VERBOSITY >= 4 then
+          if CLUTTEALTEX_VERBOSITY >= 4 then
             io.stderr:write("CluttealTeX: is_mintty: GetFileInformationByHandleEx returned ", filename, "\n")
           end
           local a, b = string.match(filename, "^\\(%w+)%-%x+%-pty%d+%-(%w+)%-master$")
           return (a == "cygwin" or a == "msys") and (b == "from" or b == "to")
         else
-          if CLUTTEX_VERBOSITY >= 4 then
+          if CLUTTEALTEX_VERBOSITY >= 4 then
             io.stderr:write("CluttealTeX: is_mintty: GetFileInformationByHandleEx failed\n")
           end
           return false
@@ -160,14 +160,14 @@ DWORD GetLastError();
           local fd = fileno(file)
           if is_mintty(fd) then
             -- MinTTY
-            if CLUTTEX_VERBOSITY >= 4 then
+            if CLUTTEALTEX_VERBOSITY >= 4 then
               io.stderr:write("CluttealTeX: Detected MinTTY\n")
             end
             return true
           elseif isatty(fd) ~= 0 then
             -- Check for ConEmu or ansicon
             if os.getenv("ConEmuANSI") == "ON" or os.getenv("ANSICON") then
-              if CLUTTEX_VERBOSITY >= 4 then
+              if CLUTTEALTEX_VERBOSITY >= 4 then
                 io.stderr:write("CluttealTeX: Detected ConEmu or ansicon\n")
               end
               return true
@@ -177,7 +177,7 @@ DWORD GetLastError();
               local modePtr = ffi.new("DWORD[1]")
               local result = GetConsoleMode(handle, modePtr)
               if result == 0 then
-                if CLUTTEX_VERBOSITY >= 3 then
+                if CLUTTEALTEX_VERBOSITY >= 3 then
                   local err = GetLastError()
                   io.stderr:write(string.format("CluttealTeX: GetConsoleMode failed (0x%08X)\n", err))
                 end
@@ -187,14 +187,14 @@ DWORD GetLastError();
               result = SetConsoleMode(handle, bitlib.bor(modePtr[0], ENABLE_VIRTUAL_TERMINAL_PROCESSING))
               if result == 0 then
                 -- SetConsoleMode failed: Command Prompt on older Windows
-                if CLUTTEX_VERBOSITY >= 3 then
+                if CLUTTEALTEX_VERBOSITY >= 3 then
                   local err = GetLastError()
                   -- Typical error code: ERROR_INVALID_PARAMETER (0x57)
                   io.stderr:write(string.format("CluttealTeX: SetConsoleMode failed (0x%08X)\n", err))
                 end
                 return false
               end
-              if CLUTTEX_VERBOSITY >= 4 then
+              if CLUTTEALTEX_VERBOSITY >= 4 then
                 io.stderr:write("CluttealTeX: Detected recent Command Prompt\n")
               end
               return true
@@ -207,12 +207,12 @@ DWORD GetLastError();
       }
   end)
   if succ then
-    if CLUTTEX_VERBOSITY >= 3 then
+    if CLUTTEALTEX_VERBOSITY >= 3 then
       io.stderr:write("CluttealTeX: isatty found via FFI (Windows)\n")
     end
     return M
   else
-    if CLUTTEX_VERBOSITY >= 3 then
+    if CLUTTEALTEX_VERBOSITY >= 3 then
       io.stderr:write("CluttealTeX: FFI (Windows) not found: ", M, "\n")
     end
   end

--- a/src_teal/texrunner/isatty.lua
+++ b/src_teal/texrunner/isatty.lua
@@ -2,20 +2,20 @@
   Copyright 2018 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 if os.type == "unix" then
@@ -38,12 +38,12 @@ int fileno(void *stream);
   end)
   if succ then
     if CLUTTEX_VERBOSITY >= 3 then
-      io.stderr:write("ClutTeX_teal: isatty found via FFI (Unix)\n")
+      io.stderr:write("CluttealTeX: isatty found via FFI (Unix)\n")
     end
     return M
   else
     if CLUTTEX_VERBOSITY >= 3 then
-      io.stderr:write("ClutTeX_teal: FFI (Unix) not found: ", M, "\n")
+      io.stderr:write("CluttealTeX: FFI (Unix) not found: ", M, "\n")
     end
   end
 
@@ -59,12 +59,12 @@ int fileno(void *stream);
   end)
   if succ then
     if CLUTTEX_VERBOSITY >= 3 then
-      io.stderr:write("ClutTeX_teal: isatty found via luaposix\n")
+      io.stderr:write("CluttealTeX: isatty found via luaposix\n")
     end
     return M
   else
     if CLUTTEX_VERBOSITY >= 3 then
-      io.stderr:write("ClutTeX_teal: luaposix not found: ", M, "\n")
+      io.stderr:write("CluttealTeX: luaposix not found: ", M, "\n")
     end
   end
 
@@ -129,7 +129,7 @@ DWORD GetLastError();
         if filetype ~= 0x0003 then -- not FILE_TYPE_PIPE (0x0003)
           -- mintty must be a pipe
           if CLUTTEX_VERBOSITY >= 4 then
-            io.stderr:write("ClutTeX_teal: is_mintty: not a pipe\n")
+            io.stderr:write("CluttealTeX: is_mintty: not a pipe\n")
           end
           return false
         end
@@ -139,13 +139,13 @@ DWORD GetLastError();
           local filename = wide_to_narrow(nameinfo.FileName, math.floor(nameinfo.FileNameLength / 2))
           -- \(cygwin|msys)-<hex digits>-pty<N>-(from|to)-master
           if CLUTTEX_VERBOSITY >= 4 then
-            io.stderr:write("ClutTeX_teal: is_mintty: GetFileInformationByHandleEx returned ", filename, "\n")
+            io.stderr:write("CluttealTeX: is_mintty: GetFileInformationByHandleEx returned ", filename, "\n")
           end
           local a, b = string.match(filename, "^\\(%w+)%-%x+%-pty%d+%-(%w+)%-master$")
           return (a == "cygwin" or a == "msys") and (b == "from" or b == "to")
         else
           if CLUTTEX_VERBOSITY >= 4 then
-            io.stderr:write("ClutTeX_teal: is_mintty: GetFileInformationByHandleEx failed\n")
+            io.stderr:write("CluttealTeX: is_mintty: GetFileInformationByHandleEx failed\n")
           end
           return false
         end
@@ -161,14 +161,14 @@ DWORD GetLastError();
           if is_mintty(fd) then
             -- MinTTY
             if CLUTTEX_VERBOSITY >= 4 then
-              io.stderr:write("ClutTeX_teal: Detected MinTTY\n")
+              io.stderr:write("CluttealTeX: Detected MinTTY\n")
             end
             return true
           elseif isatty(fd) ~= 0 then
             -- Check for ConEmu or ansicon
             if os.getenv("ConEmuANSI") == "ON" or os.getenv("ANSICON") then
               if CLUTTEX_VERBOSITY >= 4 then
-                io.stderr:write("ClutTeX_teal: Detected ConEmu or ansicon\n")
+                io.stderr:write("CluttealTeX: Detected ConEmu or ansicon\n")
               end
               return true
             else
@@ -179,7 +179,7 @@ DWORD GetLastError();
               if result == 0 then
                 if CLUTTEX_VERBOSITY >= 3 then
                   local err = GetLastError()
-                  io.stderr:write(string.format("ClutTeX_teal: GetConsoleMode failed (0x%08X)\n", err))
+                  io.stderr:write(string.format("CluttealTeX: GetConsoleMode failed (0x%08X)\n", err))
                 end
                 return false
               end
@@ -190,12 +190,12 @@ DWORD GetLastError();
                 if CLUTTEX_VERBOSITY >= 3 then
                   local err = GetLastError()
                   -- Typical error code: ERROR_INVALID_PARAMETER (0x57)
-                  io.stderr:write(string.format("ClutTeX_teal: SetConsoleMode failed (0x%08X)\n", err))
+                  io.stderr:write(string.format("CluttealTeX: SetConsoleMode failed (0x%08X)\n", err))
                 end
                 return false
               end
               if CLUTTEX_VERBOSITY >= 4 then
-                io.stderr:write("ClutTeX_teal: Detected recent Command Prompt\n")
+                io.stderr:write("CluttealTeX: Detected recent Command Prompt\n")
               end
               return true
             end
@@ -208,12 +208,12 @@ DWORD GetLastError();
   end)
   if succ then
     if CLUTTEX_VERBOSITY >= 3 then
-      io.stderr:write("ClutTeX_teal: isatty found via FFI (Windows)\n")
+      io.stderr:write("CluttealTeX: isatty found via FFI (Windows)\n")
     end
     return M
   else
     if CLUTTEX_VERBOSITY >= 3 then
-      io.stderr:write("ClutTeX_teal: FFI (Windows) not found: ", M, "\n")
+      io.stderr:write("CluttealTeX: FFI (Windows) not found: ", M, "\n")
     end
   end
 end

--- a/src_teal/texrunner/luatexinit.tl
+++ b/src_teal/texrunner/luatexinit.tl
@@ -25,7 +25,7 @@ local texio_write_nl = texio.write_nl
 local luawritelog
 local function openluawritelog()
   if not luawritelog then
-    luawritelog = assert(io_open(output_directory .. "/" .. jobname .. ".cluttex-fls", "w"))
+    luawritelog = assert(io_open(output_directory .. "/" .. jobname .. ".cluttealtex-fls", "w"))
   end
   return luawritelog
 end
@@ -41,7 +41,7 @@ io.open = function(fname, mode)
   return io_open(fname, mode)
 end
 os.execute = function(...)
-  texio_write_nl("log", string.format("CLUTTEX_EXEC %s", ...), "")
+  texio_write_nl("log", string.format("CLUTTEALTEX_EXEC %s", ...), "")
   return os_execute(...)
 end
 ]==])

--- a/src_teal/texrunner/message.tl
+++ b/src_teal/texrunner/message.tl
@@ -18,7 +18,7 @@
   along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
-global CLUTTEX_VERBOSITY: integer
+global CLUTTEALTEX_VERBOSITY: integer
 local use_colors = false
 
 local function set_colors(mode: string)
@@ -27,7 +27,7 @@ local function set_colors(mode: string)
     use_colors = true
     if use_colors and isatty.enable_virtual_terminal then
       local succ = isatty.enable_virtual_terminal(io.stderr)
-      if not succ and CLUTTEX_VERBOSITY >= 2 then
+      if not succ and CLUTTEALTEX_VERBOSITY >= 2 then
         io.stderr:write("CluttealTeX: Failed to enable virtual terminal\n")
       end
     end
@@ -36,7 +36,7 @@ local function set_colors(mode: string)
     use_colors = isatty.isatty(io.stderr)
     if use_colors and isatty.enable_virtual_terminal then
       use_colors = isatty.enable_virtual_terminal(io.stderr)
-      if not use_colors and CLUTTEX_VERBOSITY >= 2 then
+      if not use_colors and CLUTTEALTEX_VERBOSITY >= 2 then
         io.stderr:write("CluttealTeX: Failed to enable virtual terminal\n")
       end
     end

--- a/src_teal/texrunner/message.tl
+++ b/src_teal/texrunner/message.tl
@@ -1,21 +1,21 @@
 --[[
   Copyright 2018 ARATA Mizuki
-  Copyright_teal 2024 Lukas Heindl
+  Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 global CLUTTEX_VERBOSITY: integer
@@ -28,7 +28,7 @@ local function set_colors(mode: string)
     if use_colors and isatty.enable_virtual_terminal then
       local succ = isatty.enable_virtual_terminal(io.stderr)
       if not succ and CLUTTEX_VERBOSITY >= 2 then
-        io.stderr:write("ClutTeX_teal: Failed to enable virtual terminal\n")
+        io.stderr:write("CluttealTeX: Failed to enable virtual terminal\n")
       end
     end
   elseif mode == "auto" then
@@ -37,7 +37,7 @@ local function set_colors(mode: string)
     if use_colors and isatty.enable_virtual_terminal then
       use_colors = isatty.enable_virtual_terminal(io.stderr)
       if not use_colors and CLUTTEX_VERBOSITY >= 2 then
-        io.stderr:write("ClutTeX_teal: Failed to enable virtual terminal\n")
+        io.stderr:write("CluttealTeX: Failed to enable virtual terminal\n")
       end
     end
   elseif mode == "never" then

--- a/src_teal/texrunner/option.tl
+++ b/src_teal/texrunner/option.tl
@@ -2,20 +2,20 @@
 Copyright 2016 ARATA Mizuki
 Copyright 2024 Lukas Heindl
 
-This file is part of ClutTeX_teal.
+This file is part of CluttealTeX.
 
-ClutTeX_teal is free software: you can redistribute it and/or modify
+CluttealTeX is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-ClutTeX_teal is distributed in the hope that it will be useful,
+CluttealTeX is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local record Option

--- a/src_teal/texrunner/pathutil.tl
+++ b/src_teal/texrunner/pathutil.tl
@@ -2,20 +2,20 @@
   Copyright 2016 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 --[[

--- a/src_teal/texrunner/pathutil_unix.tl
+++ b/src_teal/texrunner/pathutil_unix.tl
@@ -2,20 +2,20 @@
   Copyright 2016 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal. If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX. If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 -- pathutil module for *nix

--- a/src_teal/texrunner/pathutil_windows.tl
+++ b/src_teal/texrunner/pathutil_windows.tl
@@ -2,20 +2,20 @@
   Copyright 2016 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 -- pathutil module

--- a/src_teal/texrunner/recovery.tl
+++ b/src_teal/texrunner/recovery.tl
@@ -39,7 +39,7 @@ local function create_missing_directories(args:Args): boolean
 		-- Directories for sub-auxfiles are not created automatically, so we need to provide them.
 		local report = parse_aux_file(args.auxfile, args.options.output_directory)
 		if report.made_new_directory then
-			if CLUTTEX_VERBOSITY >= 1 then
+			if CLUTTEALTEX_VERBOSITY >= 1 then
 				message.info("Created missing directories.")
 			end
 			return true
@@ -55,7 +55,7 @@ local function run_epstopdf(args:Args): boolean
 			local infile_abs = pathutil.abspath(infile, args.original_wd)
 			if fsutil.isfile(infile_abs) then -- input file exists
 				local outfile_abs = pathutil.abspath(outfile, args.options.output_directory)
-				if CLUTTEX_VERBOSITY >= 1 then
+				if CLUTTEALTEX_VERBOSITY >= 1 then
 					message.info("Running epstopdf on ", infile, ".")
 				end
 				local outdir = pathutil.dirname(outfile_abs)

--- a/src_teal/texrunner/recovery.tl
+++ b/src_teal/texrunner/recovery.tl
@@ -2,20 +2,20 @@
   Copyright 2018 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local string = string

--- a/src_teal/texrunner/reruncheck.tl
+++ b/src_teal/texrunner/reruncheck.tl
@@ -2,20 +2,20 @@
 Copyright 2016,2018 ARATA Mizuki
 Copyright 2024 Lukas Heindl
 
-This file is part of ClutTeX_teal.
+This file is part of CluttealTeX.
 
-ClutTeX_teal is free software: you can redistribute it and/or modify
+CluttealTeX is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-ClutTeX_teal is distributed in the hope that it will be useful,
+CluttealTeX is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local io = io

--- a/src_teal/texrunner/reruncheck.tl
+++ b/src_teal/texrunner/reruncheck.tl
@@ -244,7 +244,7 @@ local should_rerun = false
 							message.info("File '", fileinfo.path, "' was modified (", modified_because, ").")
 							should_rerun = true
 						else
-							if CLUTTEX_VERBOSITY >= 1 then
+							if CLUTTEALTEX_VERBOSITY >= 1 then
 								message.info("File '", fileinfo.path, "' unmodified (size and md5sum).")
 							end
 						end
@@ -279,7 +279,7 @@ local should_rerun = false
 					if should_rerun then
 						message.info("New auxiliary file '", fileinfo.path, "'.")
 					else
-						if CLUTTEX_VERBOSITY >= 1 then
+						if CLUTTEALTEX_VERBOSITY >= 1 then
 							message.info("Ignoring almost-empty auxiliary file '", fileinfo.path, "'.")
 						end
 					end

--- a/src_teal/texrunner/safename.tl
+++ b/src_teal/texrunner/safename.tl
@@ -2,20 +2,20 @@
   Copyright 2019 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local string = string

--- a/src_teal/texrunner/shellutil.tl
+++ b/src_teal/texrunner/shellutil.tl
@@ -2,20 +2,20 @@
   Copyright 2016 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 -- This module provides: shellutil.escape(s)

--- a/src_teal/texrunner/shellutil_unix.tl
+++ b/src_teal/texrunner/shellutil_unix.tl
@@ -2,20 +2,20 @@
   Copyright 2016,2019 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local assert = assert

--- a/src_teal/texrunner/shellutil_windows.tl
+++ b/src_teal/texrunner/shellutil_windows.tl
@@ -2,20 +2,20 @@
   Copyright 2016,2019 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local string_gsub = string.gsub

--- a/src_teal/texrunner/tex_engine.tl
+++ b/src_teal/texrunner/tex_engine.tl
@@ -2,20 +2,20 @@
   Copyright 2016,2019 ARATA Mizuki
   Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX_teal.
+  This file is part of CluttealTeX.
 
-  ClutTeX_teal is free software: you can redistribute it and/or modify
+  ClutTeXteal is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX_teal is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX_teal.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local table = table

--- a/utils/build_cluttealtex.lua
+++ b/utils/build_cluttealtex.lua
@@ -1,20 +1,21 @@
 --[[
   Copyright 2016, 2018 ARATA Mizuki
+  Copyright 2024 Lukas Heindl
 
-  This file is part of ClutTeX.
+  This file is part of CluttealTeX.
 
-  ClutTeX is free software: you can redistribute it and/or modify
+  CluttealTeX is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  ClutTeX is distributed in the hope that it will be useful,
+  CluttealTeX is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
   You should have received a copy of the GNU General Public License
-  along with ClutTeX.  If not, see <http://www.gnu.org/licenses/>.
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
 local srcdir = "src_lua/"
@@ -141,10 +142,10 @@ local function load_module_code(path)
 	return strip_test_code(assert(io.open(srcdir .. path, "r")):read("*a"))
 end
 
-assert(loadfile(srcdir .. "cluttex_teal.lua")) -- Check syntax
+assert(loadfile(srcdir .. "cluttealtex.lua")) -- Check syntax
 
 local shebang = nil
-local main = assert(io.open(srcdir .. "cluttex_teal.lua", "r")):read("*a")
+local main = assert(io.open(srcdir .. "cluttealtex.lua", "r")):read("*a")
 if main:sub(1,2) == "#!" then
 	-- shebang
 	shebang,main = main:match("^([^\n]+\n)(.*)$")
@@ -166,7 +167,7 @@ end
 
 if not preserve_location_info then
 	table.insert(lines, string.format("local %s = %s\n", table.concat(imported_globals, ", "), table.concat(imported_globals, ", ")))
-	table.insert(lines, "local CLUTTEX_VERBOSITY, CLUTTEX_VERSION\n")
+	table.insert(lines, "local CLUTTEALTEX_VERBOSITY, CLUTTEALTEX_VERSION\n")
 end
 
 if default_os then
@@ -188,7 +189,7 @@ if preserve_location_info then
 			table.insert(lines, string.format("package.preload[%q] = assert(loadstring(%q, %q))\n", m.name, load_module_code(m.path), "=" .. m.path))
 		end
 	end
-	table.insert(lines, string.format("assert(loadstring(%q, %q))(...)\n", main, "=cluttex_teal.lua"))
+	table.insert(lines, string.format("assert(loadstring(%q, %q))(...)\n", main, "=cluttealtex.lua"))
 else  
 	for _,m in ipairs(modules) do
 		if m.path_windows or m.path_unix then


### PR DESCRIPTION
The name `cluttex_teal` always only was a temporary name. Therefore, I plan to rename this repository, and the whole project (including the executable) to `cluttealtex`.

In theory, `teal` should implicitly made sure that I didn't break something. But still this is being tested at the moment. If you want to, feel free to test this as well and leave feedback in this PR (if something doesn't work or also if it works).