### PR TITLE
Watch filter files

### DIFF
--- a/doc/cluttealtex.tex
+++ b/doc/cluttealtex.tex
@@ -80,6 +80,19 @@ Usage:
   Watch input files for change.
   May need an external program to be available.
   See \autoref{sec:watch-mode} for details.
+\item[\texttt{--watch-only-path=\metavar{PATH}}]
+\item[\texttt{--watch-not-path=\metavar{PATH}}]
+\item[\texttt{--watch-only-ext=\metavar{EXT}}]
+\item[\texttt{--watch-not-ext=\metavar{EXT}}]
+  Watching engines often have an upper limit of how many files can be watched at once
+  (inotifywait for instance seems to only be able to watch at most 1024\footnote{\url{https://github.com/inotify-tools/inotify-tools/blob/210b019fb621d32fd6986b512508fc845f6c9fcb/src/common.cpp\#L18C20-L18C24}} files). Thus, these options provide means to filter the files that shall be watched so that this limit is not exceeded.
+
+  Note: You can use all of these options more than once.
+  They will always be processed in the order you specified them (meaning the last option will always take precedence)
+
+  Note: No matter which of these options you use, the default is always to not watch a file.
+  So by only using \texttt{--watch-not-path=./aux/} you will end up by not watching any path.
+  You can of course change this by specifying \texttt{--watch-only-path=/} before.
 \item[\texttt{--color[=\metavar{WHEN}]}]
   Colorize messages.
   \metavar{WHEN} is one of \texttt{always}, \texttt{auto}, or \texttt{never}.

--- a/src_teal/cluttealtex.tl
+++ b/src_teal/cluttealtex.tl
@@ -652,7 +652,9 @@ if options.watch then
 	end
 
 	local do_watch: function({string}):boolean
+	local max_watches: integer
 	if fswatcherlib then
+		max_watches = -1 -- no limit known to me
 		if CLUTTEALTEX_VERBOSITY >= 2 then
 			message.info("Using built-in filesystem watcher for Windows")
 		end
@@ -669,6 +671,7 @@ if options.watch then
 			return true
 		end
 	elseif (options.watch == "auto" or options.watch == "fswatch") and shellutil.has_command("fswatch") then
+		max_watches = -1 -- no limit known to me
 		if CLUTTEALTEX_VERBOSITY >= 2 then
 			message.info("Using `fswatch' command")
 		end
@@ -693,6 +696,7 @@ if options.watch then
 			return false
 		end
 	elseif (options.watch == "auto" or options.watch == "inotifywait") and shellutil.has_command("inotifywait") then
+		max_watches = 1024 -- see https://github.com/inotify-tools/inotify-tools/blob/210b019fb621d32fd6986b512508fc845f6c9fcb/src/common.cpp#L18C20-L18C24
 		if CLUTTEALTEX_VERBOSITY >= 2 then
 			message.info("Using `inotifywait' command")
 		end
@@ -734,13 +738,55 @@ if options.watch then
 	if engine.is_luatex and fsutil.isfile(recorderfile2) then
 		filelist, filemap = reruncheck.parse_recorder_file(recorderfile2, options, filelist, filemap)
 	end
-	local input_files_to_watch = {}
-	for _,fileinfo in ipairs(filelist) do
-		if fileinfo.kind == "input" then
-			table.insert(input_files_to_watch, fileinfo.abspath)
+
+	local function gather_input_files_to_watch(filelist: {reruncheck.Filemap_ele}): {string}
+		local input_files_to_watch = {}
+		for _,fileinfo in ipairs(filelist) do
+			if fileinfo.kind == "input" then
+				local watch = false
+				if options.watch_inc_exc then
+					watch = false
+					for _,v in ipairs(options.watch_inc_exc) do
+						if v.type == "only_path" then
+							if fileinfo.abspath:sub(1, #v.param) == v.param then
+								watch = true
+							end
+						elseif v.type == "only_ext" then
+							if pathutil.ext(fileinfo.abspath) == v.param then
+								watch = true
+							end
+						elseif v.type == "not_path" then
+							if fileinfo.abspath:sub(1, #v.param) == v.param then
+								watch = false
+							end
+						elseif v.type == "not_ext" then
+							if pathutil.ext(fileinfo.abspath) == v.param then
+								watch = false
+							end
+						end
+					end
+				else
+					watch = true
+				end
+
+				if watch then
+					table.insert(input_files_to_watch, fileinfo.abspath)
+				end
+			end
 		end
+		if max_watches >= 0 and #input_files_to_watch > max_watches then
+			message.warn((
+			"Collected %d input files to watch on. Typically only %d hooks are created." ..
+			"The hooks exceeding this limit typically will simply not being installed." ..
+			"Consider either to increase this limit (how/if possible depends on the watcher engine) or" ..
+			"make use of the --watch-{only,no}-{ext,path} options to restrict the files which CluttealTeX should watch."):format(
+				#input_files_to_watch, max_watches
+			))
+		end
+		return input_files_to_watch
 	end
 
+	local input_files_to_watch = gather_input_files_to_watch(filelist)
 	while do_watch(input_files_to_watch) do
 		local success, _ = do_typeset()
 		if not success then
@@ -750,12 +796,7 @@ if options.watch then
 			if engine.is_luatex and fsutil.isfile(recorderfile2) then
 				filelist, filemap = reruncheck.parse_recorder_file(recorderfile2, options, filelist, filemap)
 			end
-			input_files_to_watch = {}
-			for _,fileinfo in ipairs(filelist) do
-				if fileinfo.kind == "input" then
-					table.insert(input_files_to_watch, fileinfo.abspath)
-				end
-			end
+			input_files_to_watch = gather_input_files_to_watch(filelist)
 		end
 	end
 

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -147,6 +147,20 @@ Options:
       --watch[=ENGINE]         Watch input files for change.  Requires fswatch
                                  or inotifywait to be installed. ENGINE is one of
                                  `fswatch', `inotifywait' or `auto' [default: `auto']
+      --watch-only-path=PATH   Only watch input files that reside beneath the specified path
+                                 predecence follows the order of specified arguments
+                                 using this option automatically makes NOT watching files the default
+      --watch-not-path=PATH    Don't watch input files that reside beneath the specified path
+                                 predecence follows the order of specified arguments
+                                 using this option automatically makes NOT watching files the default
+                                 (consider using --watch-only-path=/ first if you don't want this)
+      --watch-only-ext=EXT     Only watch input files with the specified extension
+                                 predecence follows the order of specified arguments
+                                 using this option automatically makes NOT watching files the default
+      --watch-not-ext=EXT      Don't watch input files with the specified extension
+                                 predecence follows the order of specified arguments
+                                 using this option automatically makes NOT watching files the default
+                                 (consider using --watch-only-path=/ first if you don't want this)
       --tex-option=OPTION      Pass OPTION to TeX as a single option.
       --tex-options=OPTIONs    Pass OPTIONs to TeX as multiple options.
       --dvipdfmx-option[s]=OPTION[s]  Same for dvipdfmx.
@@ -239,6 +253,22 @@ local option_spec = {
 		long = "watch",
 		param = true,
 		default = "auto",
+	},
+	{
+		long = "watch-only-path",
+		param = true,
+	},
+	{
+		long = "watch-not-path",
+		param = true,
+	},
+	{
+		long = "watch-only-ext",
+		param = true,
+	},
+	{
+		long = "watch-not-ext",
+		param = true,
 	},
 	{
 		short = "h",
@@ -463,6 +493,35 @@ local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine
 			assert(options.watch == nil, "multiple --watch options")
 			if param is string then
 				options.watch = param
+			else
+				assert(param is string, "invalid param type")
+			end
+
+		elseif name == "watch-only-path" then
+			if param is string then
+				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				table.insert(options.watch_inc_exc, {param=pathutil.abspath(param),type='only_path'})
+			else
+				assert(param is string, "invalid param type")
+			end
+		elseif name == "watch-not-path" then
+			if param is string then
+				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				table.insert(options.watch_inc_exc, {param=pathutil.abspath(param),type='not_path'})
+			else
+				assert(param is string, "invalid param type")
+			end
+		elseif name == "watch-only-ext" then
+			if param is string then
+				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				table.insert(options.watch_inc_exc, {param=param,type='only_ext'})
+			else
+				assert(param is string, "invalid param type")
+			end
+		elseif name == "watch-not-ext" then
+			if param is string then
+				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				table.insert(options.watch_inc_exc, {param=param,type='not_ext'})
 			else
 				assert(param is string, "invalid param type")
 			end

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -148,17 +148,17 @@ Options:
                                  or inotifywait to be installed. ENGINE is one of
                                  `fswatch', `inotifywait' or `auto' [default: `auto']
       --watch-only-path=PATH   Only watch input files that reside beneath the specified path
-                                 predecence follows the order of specified arguments
+                                 precedence follows the order of specified arguments
                                  using this option automatically makes NOT watching files the default
       --watch-not-path=PATH    Don't watch input files that reside beneath the specified path
-                                 predecence follows the order of specified arguments
+                                 precedence follows the order of specified arguments
                                  using this option automatically makes NOT watching files the default
                                  (consider using --watch-only-path=/ first if you don't want this)
       --watch-only-ext=EXT     Only watch input files with the specified extension
-                                 predecence follows the order of specified arguments
+                                 precedence follows the order of specified arguments
                                  using this option automatically makes NOT watching files the default
       --watch-not-ext=EXT      Don't watch input files with the specified extension
-                                 predecence follows the order of specified arguments
+                                 precedence follows the order of specified arguments
                                  using this option automatically makes NOT watching files the default
                                  (consider using --watch-only-path=/ first if you don't want this)
       --tex-option=OPTION      Pass OPTION to TeX as a single option.

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -32,12 +32,17 @@ local record Module
 		synctex: string
 		tex_extraoptions: {string}
 		watch: string
+		watch_inc_exc: {WatchIncExc}
 		fmt: string
 		makeindex: string
 		sagetex: string
 		memoize: string
 		memoize_opts: {string}
 		extraoptions: {string}
+	end
+	record WatchIncExc
+		type: string
+		param: string
 	end
 	record Glos
 		type: string -- only used for splitting and cmd building


### PR DESCRIPTION
Watching engines often have an upper limit of how many files can be watched at once (inotifywait for instance seems to only be able to watch at [most 1024 files](https://github.com/inotify-tools/inotify-tools/blob/210b019fb621d32fd6986b512508fc845f6c9fcb/src/common.cpp#L18C20-L18C24)). Thus, these PR provides options to filter the files that shall be watched so that this limit is not exceeded.

**Note:** You can use all of these options more than once. They will always be processed in the order you specified them (meaning the last option will always take precedence)

**Note:** No matter which of these options you use, the default is always to not watch a file. So by only using `--watch-not-path=./aux/` you will end up by not watching any path. You can of course change this by specifying `--watch-only-path=/` before.