### PR TITLE
refactor: move the option_spec to its own file and generalize argument handling

### DIFF
--- a/Makefile.cluttealtex
+++ b/Makefile.cluttealtex
@@ -17,6 +17,7 @@ sources= \
 		 src_lua/texrunner/luatexinit.lua \
 		 src_lua/texrunner/recovery.lua \
 		 src_lua/texrunner/handleoption.lua \
+		 src_lua/texrunner/option_spec.lua \
 		 src_lua/texrunner/isatty.lua \
 		 src_lua/texrunner/message.lua \
 		 src_lua/texrunner/fswatcher_windows.lua \

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -1,417 +1,40 @@
-local COPYRIGHT_NOTICE = [[
-Copyright (C) 2016-2021  ARATA Mizuki
-Copyright (C) 2024 Lukas Heindl
+--[[
+Copyright 2016 ARATA Mizuki
+Copyright 2024 Lukas Heindl
 
-This program is free software: you can redistribute it and/or modify
+This file is part of CluttealTeX.
+
+CluttealTeX is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
+CluttealTeX is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
-local pathutil     = require "texrunner.pathutil"
-local shellutil    = require "texrunner.shellutil"
-local parseoption  = require "texrunner.option".parseoption
-local TexEngine = require "texrunner.tex_engine"
-local message      = require "texrunner.message"
-local options = require"texrunner.option_type"
+local pathutil    = require "texrunner.pathutil"
+local parseoption = require "texrunner.option".parseoption
+local options     = require "texrunner.option_type"
+local Option      = require "texrunner.option".Option
+local TexEngine   = require "texrunner.tex_engine"
+local message     = require "texrunner.message"
+local fsutil      = require "texrunner.fsutil"
+local option_spec = require "texrunner.option_spec".spec
+local usage = require "texrunner.option_spec".usage
 
 local record Module
-	usage: function({string})
 	handle_cluttealtex_options: function({string}): string,TexEngine.Engine,options.Options
 end
 
 local KnownEngines = TexEngine.KnownEngines
 global CLUTTEALTEX_VERSION:string
 
-local function split(opt:string): {string}
-	local ret,builder,state = {},{},0
-	for c in opt:gmatch(".") do
-		if state == 0 then
-			if c == ":" then
-				table.insert(ret, table.concat(builder, ""))
-				builder = {}
-			elseif c == "\\" then
-				state = 1
-			else
-				table.insert(builder, c)
-			end
-
-		elseif state == 1 then
-			-- escaped
-			table.insert(builder, c)
-			state = 0
-		end
-	end
-	table.insert(ret, table.concat(builder, ""))
-	return ret
-end
-
-local function parse_glossaries_option(opt:string): options.Glos, string
-	local s = split(opt)
-	if #s < 2 or #s > 6 then
-		return nil, "Error on splitting the glossaries parameter \""..opt.."\""
-	end
-
-	local ret:options.Glos = {}
-
-	ret.type = s[1]
-	if ret.type ~= "makeindex" and ret.type ~= "xindy" and (#s ~= 7 or s[5] == "") then
-		return nil, "Invalid glossaries parameter. \""..ret.type.."\" is unsupported"
-	end
-
-	ret.out = s[2]
-
-	if #s >= 3 and s[3] ~= "" then
-		ret.inp = s[3]
-	else
-		ret.inp = ret.out:sub(1,-2).."o"
-	end
-
-	if #s >= 4 and s[4] ~= "" then
-		ret.log = s[4]
-	else
-		ret.log = ret.out:sub(1,-2).."g"
-	end
-
-	if #s >= 5 and s[5] ~= "" then
-		ret.path = s[5]
-	else
-		ret.path = ret.type
-	end
-
-	if #s >= 6 then
-		ret.cmd = function(path_in_output_directory: function(ext:string):string):string return ret.path.." "..s[6] end
-	else
-		local foo = "%s.%s"
-		if ret.type == "makeindex" then
-			ret.cmd = function(path_in_output_directory: function(ext:string):string):string
-				return ret.path.." "..("-s %s -t %s -o %s %s"):format(
-					shellutil.escape(path_in_output_directory("ist")),
-					shellutil.escape(path_in_output_directory(ret.log)),
-					shellutil.escape(path_in_output_directory(ret.out)),
-					shellutil.escape(path_in_output_directory(ret.inp))
-				)
-			end
-		elseif ret.type == "xindy" then
-			ret.cmd = function(path_in_output_directory: function(ext:string):string):string
-				return ret.path.." "..("-M %s -t %s -o %s %s"):format(
-					shellutil.escape(path_in_output_directory("ist")),
-					shellutil.escape(path_in_output_directory(ret.log)),
-					shellutil.escape(path_in_output_directory(ret.out)),
-					shellutil.escape(path_in_output_directory(ret.inp))
-				)
-			end
-		else
-			return nil, "Error on parsing the glossaries parameter \""..opt.."\""
-		end
-	end
-
-	return ret
-end
-
-
-local function usage(arg:{string})
-	io.write(string.format([[
-ClutteakTeX: Process TeX files without cluttering your working directory
-
-Usage:
-  %s [options] [--] FILE.tex
-
-Options:
-  -e, --engine=ENGINE          Specify which TeX engine to use.
-                                 ENGINE is one of the following:
-                                     pdflatex, pdftex,
-                                     lualatex, luatex, luajittex,
-                                     xelatex, xetex, latex, etex, tex,
-                                     platex, eptex, ptex,
-                                     uplatex, euptex, uptex,
-      --engine-executable=COMMAND+OPTIONs
-                               The actual TeX command to use.
-                                 [default: ENGINE]
-  -o, --output=FILE            The name of output file.
-                                 [default: JOBNAME.pdf or JOBNAME.dvi]
-      --fresh                  Clean intermediate files before running TeX.
-                                 Cannot be used with --output-directory.
-      --max-iterations=N       Maximum number of running TeX to resolve
-                                 cross-references.  [default: 3]
-      --skip-first             Skip first run if possible [default: false]
-      --start-with-draft       Start with draft mode.
-      --[no-]change-directory  Change directory before running TeX.
-      --watch[=ENGINE]         Watch input files for change.  Requires fswatch
-                                 or inotifywait to be installed. ENGINE is one of
-                                 `fswatch', `inotifywait' or `auto' [default: `auto']
-      --watch-only-path=PATH   Only watch input files that reside beneath the specified path
-                                 precedence follows the order of specified arguments
-                                 using this option automatically makes NOT watching files the default
-      --watch-not-path=PATH    Don't watch input files that reside beneath the specified path
-                                 precedence follows the order of specified arguments
-                                 using this option automatically makes NOT watching files the default
-                                 (consider using --watch-only-path=/ first if you don't want this)
-      --watch-only-ext=EXT     Only watch input files with the specified extension
-                                 precedence follows the order of specified arguments
-                                 using this option automatically makes NOT watching files the default
-      --watch-not-ext=EXT      Don't watch input files with the specified extension
-                                 precedence follows the order of specified arguments
-                                 using this option automatically makes NOT watching files the default
-                                 (consider using --watch-only-path=/ first if you don't want this)
-      --tex-option=OPTION      Pass OPTION to TeX as a single option.
-      --tex-options=OPTIONs    Pass OPTIONs to TeX as multiple options.
-      --dvipdfmx-option[s]=OPTION[s]  Same for dvipdfmx.
-      --makeindex=COMMAND+OPTIONs   Command to generate index, such as
-                                     `makeindex' or `mendex'.
-      --bibtex=COMMAND+OPTIONs      Command for BibTeX, such as
-                                     `bibtex' or `pbibtex'.
-      --biber[=COMMAND+OPTIONs]     Command for Biber.
-      --sagetex[=COMMAND+OPTIONS]   Command for sagetex
-      --memoize[=python/perl/path]  Command which shall be used for memoize
-      --memoize_opt=PACKAGE_OPT     Additional package option for memoize
-      --glossaries=[CONFIGURATION]  Configuration can contain
-                                    "type:outputFile:inputFile:logFile:pathToCommand:commandArgs" (":" can be escaped with "\").
-                                    Only the outputFile and either type or pathToCommand
-                                    are required, the other options will be infered
-                                    automatically (does not work always for inputFile and
-                                    logFile). If commandArgs is being specified,
-                                    these will be the only arguments passed to the
-                                    command. If type is unspecified commandArgs must be
-                                    specified. As types we support makeindex and xindy.
-                                    Specify this option multiple times to register multiple
-                                    glossaries. The default value works for a
-                                    configuration with the usual glossary (glo,gls,glg)
-                                    A typical example is
-                                    "makeindex:acr:acn:alg" or
-                                    "makeindex:glo:gls:glg" (default)
-  -h, --help                   Print this message and exit.
-  -v, --version                Print version information and exit.
-  -V, --verbose                Be more verbose.
-      --color[=WHEN]           Make CluttealTeX's message colorful. WHEN is one of
-                                 `always', `auto', or `never'.
-                                 [default: `auto' if --color is omitted,
-                                           `always' if WHEN is omitted]
-      --includeonly=NAMEs      Insert '\includeonly{NAMEs}'.
-      --make-depends=FILE      Write dependencies as a Makefile rule.
-      --print-output-directory  Print the output directory and exit.
-      --package-support=PKG1[,PKG2,...]
-                               Enable special support for some shell-escaping
-                                 packages.
-                               Currently supported: minted, epstopdf
-      --check-driver=DRIVER    Check that the correct driver file is loaded.
-                               DRIVER is one of `dvipdfmx', `dvips', `dvisvgm'.
-
-      --[no-]shell-escape
-      --shell-restricted
-      --synctex=NUMBER
-      --fmt=FMTNAME
-      --[no-]file-line-error   [default: yes]
-      --[no-]halt-on-error     [default: yes]
-      --interaction=STRING     [default: nonstopmode]
-      --jobname=STRING
-      --output-directory=DIR   [default: somewhere in the temporary directory]
-      --output-format=FORMAT   FORMAT is `pdf' or `dvi'.  [default: pdf]
-
-%s
-]], arg[0] or 'texlua cluttealtex.lua', COPYRIGHT_NOTICE))
-end
-
-local option_spec = {
-	-- Options for CluttealTeX
-	{
-		short = "e",
-		long = "engine",
-		param = true,
-	},
-	{
-		long = "engine-executable",
-		param = true,
-	},
-	{
-		short = "o",
-		long = "output",
-		param = true,
-	},
-	{
-		long = "fresh",
-	},
-	{
-		long = "max-iterations",
-		param = true,
-	},
-	{
-		long = "skip-first",
-	},
-	{
-		long = "start-with-draft",
-	},
-	{
-		long = "change-directory",
-		boolean = true,
-	},
-	{
-		long = "watch",
-		param = true,
-		default = "auto",
-	},
-	{
-		long = "watch-only-path",
-		param = true,
-	},
-	{
-		long = "watch-not-path",
-		param = true,
-	},
-	{
-		long = "watch-only-ext",
-		param = true,
-	},
-	{
-		long = "watch-not-ext",
-		param = true,
-	},
-	{
-		short = "h",
-		long = "help",
-		allow_single_hyphen = true,
-	},
-	{
-		short = "v",
-		long = "version",
-	},
-	{
-		short = "V",
-		long = "verbose",
-	},
-	{
-		long = "color",
-		param = true,
-		default = "always",
-	},
-	{
-		long = "includeonly",
-		param = true,
-	},
-	{
-		long = "make-depends",
-		param = true
-	},
-	{
-		long = "print-output-directory",
-	},
-	{
-		long = "package-support",
-		param = true
-	},
-	{
-		long = "check-driver",
-		param = true
-	},
-	-- Options for TeX
-	{
-		long = "synctex",
-		param = true,
-		allow_single_hyphen = true,
-	},
-	{
-		long = "file-line-error",
-		boolean = true,
-		allow_single_hyphen = true,
-	},
-	{
-		long = "interaction",
-		param = true,
-		allow_single_hyphen = true,
-	},
-	{
-		long = "halt-on-error",
-		boolean = true,
-		allow_single_hyphen = true,
-	},
-	{
-		long = "shell-escape",
-		boolean = true,
-		allow_single_hyphen = true,
-	},
-	{
-		long = "shell-restricted",
-		allow_single_hyphen = true,
-	},
-	{
-		long = "jobname",
-		param = true,
-		allow_single_hyphen = true,
-	},
-	{
-		long = "fmt",
-		param = true,
-		allow_single_hyphen = true,
-	},
-	{
-		long = "output-directory",
-		param = true,
-		allow_single_hyphen = true,
-	},
-	{
-		long = "output-format",
-		param = true,
-		allow_single_hyphen = true,
-	},
-	{
-		long = "tex-option",
-		param = true,
-	},
-	{
-		long = "tex-options",
-		param = true,
-	},
-	{
-		long = "dvipdfmx-option",
-		param = true,
-	},
-	{
-		long = "dvipdfmx-options",
-		param = true,
-	},
-	{
-		long = "makeindex",
-		param = true,
-		default = "makeindex",
-	},
-	{
-		long = "bibtex",
-		param = true,
-		default = "bibtex",
-	},
-	{
-		long = "biber",
-		param = true,
-		default = "biber",
-	},
-	{
-		long = "sagetex",
-		param = true,
-		default = "sage",
-	},
-	{
-		long = "glossaries",
-		param = true,
-		default = "makeindex:main.glo:main.gls:main.glg",
-	},
-	{
-		long = "memoize",
-		param = true,
-		default = "perl",
-	},
-	{
-		long = "memoize_opt",
-		param = true,
-	},
-}
 
 -- Default values for options
 local function set_default_values(options:options.Options)
@@ -440,355 +63,49 @@ local function set_default_values(options:options.Options)
 	end
 end
 
+-- built up a lookup table over short and long options in order to speed up argument parsing
+local option_spec_lut:{string:{any:string}} = {long={}, short={}}
+for k,v in pairs(option_spec) do
+	if v.long then
+		option_spec_lut.long[v.long] = k
+	end
+	if v.short then
+		option_spec_lut.short[v.short] = k
+	end
+end
+local function query_long_options(name:string):Option,string,boolean
+	local no = false
+	local key = option_spec_lut.long[name]
+	if not key then
+		key = option_spec_lut.long["no-"..name]
+		no = true
+	end
+	return option_spec[key], key, no
+end
+local function query_short_options(name:string):Option,string,boolean
+	local key = option_spec_lut.short[name]
+	return option_spec[key], key, false
+end
+
+
 -- inputfile, engine, options = handle_cluttealtex_options(arg)
 local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine,options.Options
-	-- Parse options
-	local option_and_params, non_option_index = parseoption(arg, option_spec)
-
-	-- Handle options
+	-- Store options
 	local options:options.Options = {
 		tex_extraoptions = {},
 		dvipdfmx_extraoptions = {},
 		package_support = {},
 	}
+
+	-- Parse options from commandline
+	local option_and_params, non_option_index = parseoption(arg, query_long_options, query_short_options)
+
+	-- Handle options
 	CLUTTEALTEX_VERBOSITY = 0
 	for _,option in ipairs(option_and_params) do
-		local name:string = option[1]
+		local optname:string = option[1]
 		local param:string|boolean = option[2]
-
-		if name == "engine" then
-			assert(options.engine == nil, "multiple --engine options")
-			if param is string then
-				options.engine = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "engine-executable" then
-			assert(options.engine_executable == nil, "multiple --engine-executable options")
-			if param is string then
-				options.engine_executable = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "output" then
-			assert(options.output == nil, "multiple --output options")
-			if param is string then
-				options.output = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "fresh" then
-			assert(options.fresh == nil, "multiple --fresh options")
-			if param is string then
-				options.fresh = true
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "max-iterations" then
-			assert(options.max_iterations == nil, "multiple --max-iterations options")
-			options.max_iterations = assert(tonumber(param) as integer, "invalid value for --max-iterations option")
-			assert(options.max_iterations >= 1, "invalid value for --max-iterations option")
-
-		elseif name == "skip-first" then
-			-- assert(options.skip_first == nil, "multiple --skip-first options")
-			-- options.skip_first = param == "true"
-			options.skip_first = true
-
-		elseif name == "start-with-draft" then
-			assert(options.start_with_draft == nil, "multiple --start-with-draft options")
-			options.start_with_draft = true
-
-		elseif name == "watch" then
-			assert(options.watch == nil, "multiple --watch options")
-			if param is string then
-				options.watch = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "watch-only-path" then
-			if param is string then
-				if not options.watch_inc_exc then options.watch_inc_exc = {} end
-				table.insert(options.watch_inc_exc, {param=pathutil.abspath(param),type='only_path'})
-			else
-				error("invalid param type")
-			end
-		elseif name == "watch-not-path" then
-			if param is string then
-				if not options.watch_inc_exc then options.watch_inc_exc = {} end
-				table.insert(options.watch_inc_exc, {param=pathutil.abspath(param),type='not_path'})
-			else
-				error("invalid param type")
-			end
-		elseif name == "watch-only-ext" then
-			if param is string then
-				if not options.watch_inc_exc then options.watch_inc_exc = {} end
-				table.insert(options.watch_inc_exc, {param=param,type='only_ext'})
-			else
-				error("invalid param type")
-			end
-		elseif name == "watch-not-ext" then
-			if param is string then
-				if not options.watch_inc_exc then options.watch_inc_exc = {} end
-				table.insert(options.watch_inc_exc, {param=param,type='not_ext'})
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "help" then
-			usage(arg)
-			os.exit(0)
-
-		elseif name == "version" then
-			io.stderr:write("cluttealtex ",CLUTTEALTEX_VERSION,"\n")
-			os.exit(0)
-
-		elseif name == "verbose" then
-			CLUTTEALTEX_VERBOSITY = CLUTTEALTEX_VERBOSITY + 1
-
-		elseif name == "color" then
-			assert(options.color == nil, "multiple --color options")
-			if param is string then
-				options.color = param
-			else
-				error("invalid param type")
-			end
-			message.set_colors(options.color)
-
-		elseif name == "change-directory" then
-			assert(options.change_directory == nil, "multiple --change-directory options")
-			if param is boolean then
-				options.change_directory = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "includeonly" then
-			assert(options.includeonly == nil, "multiple --includeonly options")
-			if param is string then
-				options.includeonly = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "make-depends" then
-			assert(options.make_depends == nil, "multiple --make-depends options")
-			if param is string then
-				options.make_depends = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "print-output-directory" then
-			assert(options.print_output_directory == nil, "multiple --print-output-directory options")
-			if param is string then
-				options.print_output_directory = true
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "package-support" then
-			local known_packages:{string:boolean} = {["minted"] = true, ["epstopdf"] = true}
-			if param is string then
-				for pkg in string.gmatch(param, "[^,%s]+") do
-					options.package_support[pkg] = true
-					if not known_packages[pkg] and CLUTTEALTEX_VERBOSITY >= 1 then
-						message.warn("CluttealTeX provides no special support for '"..pkg.."'.")
-					end
-				end
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "check-driver" then
-			assert(options.check_driver == nil, "multiple --check-driver options")
-			assert(param == "dvipdfmx" or param == "dvips" or param == "dvisvgm", "wrong value for --check-driver option")
-			if param is string then
-				options.check_driver = param
-			else
-				assert(param is string, "invalid param type")
-			end
-
-			-- Options for TeX
-		elseif name == "synctex" then
-			assert(options.synctex == nil, "multiple --synctex options")
-			if param is string then
-				options.synctex = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "file-line-error" then
-			if param is boolean then
-				options.file_line_error = param
-			else
-				assert(param is string, "invalid param type")
-			end
-
-		elseif name == "interaction" then
-			assert(options.interaction == nil, "multiple --interaction options")
-			if param is string then
-				assert(param == "batchmode" or param == "nonstopmode" or param == "scrollmode" or param == "errorstopmode", "invalid argument for --interaction")
-				options.interaction = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "halt-on-error" then
-			if param is boolean then
-				options.halt_on_error = param
-			else
-				assert(param is string, "invalid param type")
-			end
-
-		elseif name == "shell-escape" then
-			assert(options.shell_escape == nil and options.shell_restricted == nil, "multiple --(no-)shell-escape or --shell-restricted options")
-			if param is boolean then
-				options.shell_escape = param
-			else
-				assert(param is string, "invalid param type")
-			end
-
-		elseif name == "shell-restricted" then
-			assert(options.shell_escape == nil and options.shell_restricted == nil, "multiple --(no-)shell-escape or --shell-restricted options")
-			options.shell_restricted = true
-
-		elseif name == "jobname" then
-			assert(options.jobname == nil, "multiple --jobname options")
-			if param is string then
-				options.jobname = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "fmt" then
-			assert(options.fmt == nil, "multiple --fmt options")
-			if param is string then
-				options.fmt = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "output-directory" then
-			assert(options.output_directory == nil, "multiple --output-directory options")
-			if param is string then
-				options.output_directory = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "output-format" then
-			assert(options.output_format == nil, "multiple --output-format options")
-			assert(param == "pdf" or param == "dvi", "invalid argument for --output-format")
-			if param is string then
-				options.output_format = param
-			else
-				assert(param is string, "invalid param type")
-			end
-
-		elseif name == "tex-option" then
-			if param is string then
-				table.insert(options.tex_extraoptions, shellutil.escape(param))
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "tex-options" then
-			if param is string then
-				table.insert(options.tex_extraoptions, param)
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "dvipdfmx-option" then
-			if param is string then
-				table.insert(options.dvipdfmx_extraoptions, shellutil.escape(param))
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "dvipdfmx-options" then
-			if param is string then
-				table.insert(options.dvipdfmx_extraoptions, param)
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "makeindex" then
-			assert(not options.glossaries, "'makeindex' cannot be used together with 'glossaries'\nUse e.g. --glossaries='makeindex:main.ind:main.idx:main.ilg' instead of makeindex")
-			assert(options.makeindex == nil, "multiple --makeindex options")
-			if param is string then
-				options.makeindex = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "bibtex" then
-			assert(options.bibtex == nil, "multiple --bibtex options")
-			assert(options.biber == nil, "multiple --bibtex/--biber options")
-			if param is string then
-				options.bibtex = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "biber" then
-			assert(options.biber == nil, "multiple --biber options")
-			assert(options.bibtex == nil, "multiple --bibtex/--biber options")
-			if param is string then
-				options.biber = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "glossaries" then
-			assert(not options.makeindex, "'glossaries' cannot be used together with 'makeindex'\nUse e.g. --glossaries='makeindex:main.ind:main.idx:main.ilg' instead of makeindex")
-			if not options.glossaries then
-				options.glossaries = {}
-			end
-			if param is string then
-				local cfg = assert(parse_glossaries_option(param))
-				table.insert(options.glossaries, cfg)
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "sagetex" then
-			assert(options.sagetex == nil, "multiple --sagetex options")
-			if param is string then
-				options.sagetex = param
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "memoize" then
-			assert(options.memoize == nil, "multiple --memoize options")
-			if param is string then
-				if param == "python" then
-					options.memoize = "memoize-extract.py"
-				elseif param == "perl" then
-					options.memoize = "memoize-extract.pl"
-				else
-					options.memoize = param
-				end
-			else
-				error("invalid param type")
-			end
-
-		elseif name == "memoize_opt" then
-			if param is string then
-				options.memoize_opts = options.memoize_opts or {}
-				table.insert(options.memoize_opts, param)
-			else
-				error("invalid param type")
-			end
-
-		end
-
+		assert(option_spec[optname], "invalid optname found").handle_cli(options, param)
 	end
 
 	if options.color == nil then
@@ -861,7 +178,6 @@ local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine
 end
 
 local _M:Module = {
-	usage = usage,
 	handle_cluttealtex_options = handle_cluttealtex_options,
 }
 return _M

--- a/src_teal/texrunner/option.tl
+++ b/src_teal/texrunner/option.tl
@@ -25,13 +25,14 @@ local record Option
 	allow_single_hyphen: boolean
 	default: string
 	boolean: boolean
+	handle_cli: function({string:any}, string|boolean)
 end
 
 -- options_and_params, i = parseoption(arg, options)
 -- options[i] = {short = "o", long = "option" [, param = true] [, boolean = true] [, allow_single_hyphen = false]}
 -- options_and_params[j] = {"option", "value"}
 -- arg[i], arg[i + 1], ..., arg[#arg] are non-options
-local function parseoption(arg:{string}, options:{Option}): {{string,string|boolean}},integer
+local function parseoption(arg:{string}, query_long_options:(function(string):Option,string,boolean), query_short_options:(function(string):Option,string,boolean)): {{string,string|boolean}},integer
 local i = 1
 	local option_and_params:{{string,string|boolean}} = {}
 	while i <= #arg do
@@ -40,115 +41,116 @@ local i = 1
 			i = i + 1
 			break
 		elseif arg[i]:sub(1,2) == "--" then
-			-- Long option
+			-- two hypens
 			local param:string|boolean
 			local name:string
 			name,param = arg[i]:match("^([^=]+)=(.*)$", 3)
 			name = name or arg[i]:sub(3)
-			local opt:Option = nil
-			for _,o in ipairs(options) do
-				if o.long then
-					if o.long == name then
-						if o.param then
-							if param then
-								-- --option=param
-							else
-								if o.default ~= nil then
-									param = o.default
-								else
-									-- --option param
-									assert(i + 1 <= #arg, "argument missing after " .. arg[i] .. " option")
-									param = arg[i + 1]
-									i = i + 1
-								end
-							end
+			local opt, optname, no_opt = query_long_options(name)
+			if opt and opt.long then
+				-- option was found as long option with two hypens
+				if not no_opt then
+					-- option is "normal" (no 'no-' prefix)
+					-- check if option takes an argument
+					if opt.param then
+						if param then
+							-- --option=param
 						else
-							-- --option
-							param = true
+							if opt.default ~= nil then
+								-- no param with space if option specifies a
+								-- default in order to avoid accidentally
+								-- consuming the next argument
+								param = opt.default
+							else
+								-- --option param
+								assert(i + 1 <= #arg, "argument missing after " .. arg[i] .. " option")
+								param = arg[i + 1]
+								i = i + 1
+							end
 						end
-						opt = o
-						break
-					elseif o.boolean and name == "no-" .. o.long then
-						-- --no-option
-						opt = o
-						param = false
-						break
+					else
+						-- --option
+						param = true
 					end
+				elseif opt.boolean and no_opt then
+					-- --no-option
+					param = false
+				else
+					error("no- option can't have a value assigned to it")
 				end
-			end
-			if opt then
-				table.insert(option_and_params, {opt.long, param})
+				table.insert(option_and_params, {optname, param})
 			else
 				-- Unknown long option
 				error("unknown long option: " .. arg[i])
 			end
+
 		elseif arg[i]:sub(1,1) == "-" then
+			-- one hypen
 			local param:string|boolean
 			local name:string
 			name,param = arg[i]:match("^([^=]+)=(.*)$", 2)
 			name = name or arg[i]:sub(2)
-			local opt:Option = nil
-			for _,o in ipairs(options) do
-				if o.long and o.allow_single_hyphen then
-					if o.long == name then
-						if o.param then
-							if param then
-								-- -option=param
-							else
-								if o.default ~= nil then
-									param = o.default
-								else
-									-- -option param
-									assert(i + 1 <= #arg, "argument missing after " .. arg[i] .. " option")
-									param = arg[i + 1]
-									i = i + 1
-								end
-							end
+			local opt, optname, no_opt = query_long_options(name)
+			if opt and opt.long and opt.allow_single_hyphen then
+				if not no_opt then
+					if opt.param then
+						if param then
+							-- -option=param
 						else
-							-- -option
-							param = true
+							if opt.default ~= nil then
+								-- no param with space if option specifies a
+								-- default in order to avoid accidentally
+								-- consuming the next argument
+								param = opt.default
+							else
+								-- -option param
+								assert(i + 1 <= #arg, "argument missing after " .. arg[i] .. " option")
+								param = arg[i + 1]
+								i = i + 1
+							end
 						end
-						opt = o
-						break
-					elseif o.boolean and name == "no-" .. o.long then
-						-- -no-option
-						opt = o
-						param = false
-						break
+					else
+						-- -option
+						param = true
 					end
-				elseif o.long and #name >= 2 and (o.long == name or (o.boolean and name == "no-" .. o.long)) then
-					error("You must supply two hyphens (i.e. --" .. name .. ") for long option")
+				elseif opt.boolean and no_opt then
+					-- -no-option
+					param = false
+				else
+					error("no- option can't have a value assigned to it")
 				end
+			elseif opt and opt.long and #name >= 2 then
+				error("You must supply two hyphens (i.e. --" .. name .. ") for long option")
 			end
+
+			-- parse as short option if not able to parse as long option with one hypen
 			if opt == nil then
 				-- Short option
 				name = arg[i]:sub(2,2)
-				for _,o in ipairs(options) do
-					if o.short then
-						if o.short == name then
-							if o.param then
-								if #arg[i] > 2 then
-									-- -oparam
-									param = arg[i]:sub(3)
-								else
-									-- -o param
-									assert(i + 1 <= #arg, "argument missing after " .. arg[i] .. " option")
-									param = arg[i + 1]
-									i = i + 1
-								end
-							else
-								-- -o
-								assert(#arg[i] == 2, "combining multiple short options like -abc is not supported")
-								param = true
-							end
-							opt = o
-							break
+				opt, optname = query_short_options(name)
+				if opt and opt.short then
+					-- option was found as short option
+					if opt.param then
+						if #arg[i] > 2 then
+							-- -oparam
+							param = arg[i]:sub(3)
+						else
+						-- passing arguments separated with space is common with short options
+						-- -> no default here TODO not a nice consistent behavior
+							-- -o param
+							assert(i + 1 <= #arg, "argument missing after " .. arg[i] .. " option")
+							param = arg[i + 1]
+							i = i + 1
 						end
+					else
+						-- -o
+						assert(#arg[i] == 2, "combining multiple short options like -abc is not supported")
+						param = true
 					end
 				end
 			end
 			if opt then
-				table.insert(option_and_params, {opt.long or opt.short, param})
+				table.insert(option_and_params, {optname, param})
 			else
 				error("unknown short option: " .. arg[i])
 			end
@@ -162,5 +164,6 @@ local i = 1
 end
 
 return {
-	parseoption = parseoption;
+	parseoption = parseoption,
+	Option      = Option,
 }

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -1,0 +1,744 @@
+local COPYRIGHT_NOTICE = [[
+Copyright (C) 2016-2021  ARATA Mizuki
+Copyright (C) 2024 Lukas Heindl
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+]]
+
+local Option  = require "texrunner.option".Option
+local shellutil   = require "texrunner.shellutil"
+local options = require"texrunner.option_type"
+local pathutil    = require "texrunner.pathutil"
+local message     = require "texrunner.message"
+
+global CLUTTEALTEX_VERSION:string
+
+local function split(opt:string): {string}
+	local ret,builder,state = {},{},0
+	for c in opt:gmatch(".") do
+		if state == 0 then
+			if c == ":" then
+				table.insert(ret, table.concat(builder, ""))
+				builder = {}
+			elseif c == "\\" then
+				state = 1
+			else
+				table.insert(builder, c)
+			end
+
+		elseif state == 1 then
+			-- escaped
+			table.insert(builder, c)
+			state = 0
+		end
+	end
+	table.insert(ret, table.concat(builder, ""))
+	return ret
+end
+
+local function parse_glossaries_option(opt:string): options.Glos, string
+	local s = split(opt)
+	if #s < 2 or #s > 6 then
+		return nil, "Error on splitting the glossaries parameter \""..opt.."\""
+	end
+
+	local ret:options.Glos = {}
+
+	ret.type = s[1]
+	if ret.type ~= "makeindex" and ret.type ~= "xindy" and (#s ~= 7 or s[5] == "") then
+		return nil, "Invalid glossaries parameter. \""..ret.type.."\" is unsupported"
+	end
+
+	ret.out = s[2]
+
+	if #s >= 3 and s[3] ~= "" then
+		ret.inp = s[3]
+	else
+		ret.inp = ret.out:sub(1,-2).."o"
+	end
+
+	if #s >= 4 and s[4] ~= "" then
+		ret.log = s[4]
+	else
+		ret.log = ret.out:sub(1,-2).."g"
+	end
+
+	if #s >= 5 and s[5] ~= "" then
+		ret.path = s[5]
+	else
+		ret.path = ret.type
+	end
+
+	if #s >= 6 then
+		ret.cmd = function(path_in_output_directory: function(ext:string):string):string return ret.path.." "..s[6] end
+	else
+		local foo = "%s.%s"
+		if ret.type == "makeindex" then
+			ret.cmd = function(path_in_output_directory: function(ext:string):string):string
+				return ret.path.." "..("-s %s -t %s -o %s %s"):format(
+					shellutil.escape(path_in_output_directory("ist")),
+					shellutil.escape(path_in_output_directory(ret.log)),
+					shellutil.escape(path_in_output_directory(ret.out)),
+					shellutil.escape(path_in_output_directory(ret.inp))
+				)
+			end
+		elseif ret.type == "xindy" then
+			ret.cmd = function(path_in_output_directory: function(ext:string):string):string
+				return ret.path.." "..("-M %s -t %s -o %s %s"):format(
+					shellutil.escape(path_in_output_directory("ist")),
+					shellutil.escape(path_in_output_directory(ret.log)),
+					shellutil.escape(path_in_output_directory(ret.out)),
+					shellutil.escape(path_in_output_directory(ret.inp))
+				)
+			end
+		else
+			return nil, "Error on parsing the glossaries parameter \""..opt.."\""
+		end
+	end
+
+	return ret
+end
+
+local function usage(arg:{string})
+	io.write(string.format([[
+ClutteakTeX: Process TeX files without cluttering your working directory
+
+Usage:
+  %s [options] [--] FILE.tex
+
+Options:
+  -e, --engine=ENGINE          Specify which TeX engine to use.
+                                 ENGINE is one of the following:
+                                     pdflatex, pdftex,
+                                     lualatex, luatex, luajittex,
+                                     xelatex, xetex, latex, etex, tex,
+                                     platex, eptex, ptex,
+                                     uplatex, euptex, uptex,
+      --engine-executable=COMMAND+OPTIONs
+                               The actual TeX command to use.
+                                 [default: ENGINE]
+  -o, --output=FILE            The name of output file.
+                                 [default: JOBNAME.pdf or JOBNAME.dvi]
+      --fresh                  Clean intermediate files before running TeX.
+                                 Cannot be used with --output-directory.
+      --max-iterations=N       Maximum number of running TeX to resolve
+                                 cross-references.  [default: 3]
+      --skip-first             Skip first run if possible [default: false]
+      --start-with-draft       Start with draft mode.
+      --[no-]change-directory  Change directory before running TeX.
+      --watch[=ENGINE]         Watch input files for change.  Requires fswatch
+                                 or inotifywait to be installed. ENGINE is one of
+                                 `fswatch', `inotifywait' or `auto' [default: `auto']
+      --watch-only-path=PATH   Only watch input files that reside beneath the specified path
+                                 precedence follows the order of specified arguments
+                                 using this option automatically makes NOT watching files the default
+      --watch-not-path=PATH    Don't watch input files that reside beneath the specified path
+                                 precedence follows the order of specified arguments
+                                 using this option automatically makes NOT watching files the default
+                                 (consider using --watch-only-path=/ first if you don't want this)
+      --watch-only-ext=EXT     Only watch input files with the specified extension
+                                 precedence follows the order of specified arguments
+                                 using this option automatically makes NOT watching files the default
+      --watch-not-ext=EXT      Don't watch input files with the specified extension
+                                 precedence follows the order of specified arguments
+                                 using this option automatically makes NOT watching files the default
+                                 (consider using --watch-only-path=/ first if you don't want this)
+      --tex-option=OPTION      Pass OPTION to TeX as a single option.
+      --tex-options=OPTIONs    Pass OPTIONs to TeX as multiple options.
+      --dvipdfmx-option[s]=OPTION[s]  Same for dvipdfmx.
+      --makeindex=COMMAND+OPTIONs   Command to generate index, such as
+                                     `makeindex' or `mendex'.
+      --bibtex=COMMAND+OPTIONs      Command for BibTeX, such as
+                                     `bibtex' or `pbibtex'.
+      --biber[=COMMAND+OPTIONs]     Command for Biber.
+      --sagetex[=COMMAND+OPTIONS]   Command for sagetex
+      --memoize[=python/perl/path]  Command which shall be used for memoize
+      --memoize_opt=PACKAGE_OPT     Additional package option for memoize
+      --glossaries=[CONFIGURATION]  Configuration can contain
+                                    "type:outputFile:inputFile:logFile:pathToCommand:commandArgs" (":" can be escaped with "\").
+                                    Only the outputFile and either type or pathToCommand
+                                    are required, the other options will be infered
+                                    automatically (does not work always for inputFile and
+                                    logFile). If commandArgs is being specified,
+                                    these will be the only arguments passed to the
+                                    command. If type is unspecified commandArgs must be
+                                    specified. As types we support makeindex and xindy.
+                                    Specify this option multiple times to register multiple
+                                    glossaries. The default value works for a
+                                    configuration with the usual glossary (glo,gls,glg)
+                                    A typical example is
+                                    "makeindex:acr:acn:alg" or
+                                    "makeindex:glo:gls:glg" (default)
+  -h, --help                   Print this message and exit.
+  -v, --version                Print version information and exit.
+  -V, --verbose                Be more verbose.
+      --color[=WHEN]           Make CluttealTeX's message colorful. WHEN is one of
+                                 `always', `auto', or `never'.
+                                 [default: `auto' if --color is omitted,
+                                           `always' if WHEN is omitted]
+      --includeonly=NAMEs      Insert '\includeonly{NAMEs}'.
+      --make-depends=FILE      Write dependencies as a Makefile rule.
+      --print-output-directory  Print the output directory and exit.
+      --package-support=PKG1[,PKG2,...]
+                               Enable special support for some shell-escaping
+                                 packages.
+                               Currently supported: minted, epstopdf
+      --check-driver=DRIVER    Check that the correct driver file is loaded.
+                               DRIVER is one of `dvipdfmx', `dvips', `dvisvgm'.
+
+      --[no-]shell-escape
+      --shell-restricted
+      --synctex=NUMBER
+      --fmt=FMTNAME
+      --[no-]file-line-error   [default: yes]
+      --[no-]halt-on-error     [default: yes]
+      --interaction=STRING     [default: nonstopmode]
+      --jobname=STRING
+      --output-directory=DIR   [default: somewhere in the temporary directory]
+      --output-format=FORMAT   FORMAT is `pdf' or `dvi'.  [default: pdf]
+
+%s
+]], arg[0] or 'texlua cluttealtex.lua', COPYRIGHT_NOTICE))
+end
+
+
+local option_spec:{string:Option} = {
+	-- Options for CluttealTeX
+	engine = {
+		short = "e",
+		long = "engine",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.engine == nil, "multiple --engine options")
+			if param is string then
+				options.engine = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	engine_executable = {
+		long = "engine-executable",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.engine_executable == nil, "multiple --engine-executable options")
+			if param is string then
+				options.engine_executable = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	output = {
+		short = "o",
+		long = "output",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.output == nil, "multiple --output options")
+			if param is string then
+				options.output = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	fresh = {
+		long = "fresh",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.fresh == nil, "multiple --fresh options")
+			if param is string then
+				options.fresh = true
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	max_iterations = {
+		long = "max-iterations",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.max_iterations == nil, "multiple --max-iterations options")
+			options.max_iterations = assert(tonumber(param) as integer, "invalid value for --max-iterations option")
+			assert(options.max_iterations >= 1, "invalid value for --max-iterations option")
+		end
+	},
+	skip_first = {
+		long = "skip-first",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.skip_first == nil, "multiple --skip-first options")
+			options.skip_first = true
+		end
+	},
+	start_with_draft = {
+		long = "start-with-draft",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.start_with_draft == nil, "multiple --start-with-draft options")
+			options.start_with_draft = true
+		end
+	},
+	change_directory = {
+		long = "change-directory",
+		boolean = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.change_directory == nil, "multiple --change-directory options")
+				if param is boolean then
+					options.change_directory = param
+					else
+					error("invalid param type")
+				end
+			end
+	},
+	watch = {
+		long = "watch",
+		param = true,
+		default = "auto",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.watch == nil, "multiple --watch options")
+			if param is string then
+				options.watch = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	watch_only_path = {
+		long = "watch-only-path",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				table.insert(options.watch_inc_exc, {param=pathutil.abspath(param),type='only_path'})
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	watch_not_path = {
+		long = "watch-not-path",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				table.insert(options.watch_inc_exc, {param=pathutil.abspath(param),type='not_path'})
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	watch_only_ext = {
+		long = "watch-only-ext",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				table.insert(options.watch_inc_exc, {param=param,type='only_ext'})
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	watch_not_ext = {
+		long = "watch-not-ext",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				table.insert(options.watch_inc_exc, {param=param,type='not_ext'})
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	help = {
+		short = "h",
+		long = "help",
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			usage(arg)
+			os.exit(0)
+		end
+	},
+	version = {
+		short = "v",
+		long = "version",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			io.stderr:write("cluttealtex ",CLUTTEALTEX_VERSION,"\n")
+			os.exit(0)
+		end
+	},
+	verbose = {
+		short = "V",
+		long = "verbose",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			CLUTTEALTEX_VERBOSITY = CLUTTEALTEX_VERBOSITY + 1
+		end
+	},
+	color = {
+		long = "color",
+		param = true,
+		default = "always",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.color == nil, "multiple --color options")
+			if param is string then
+				options.color = param
+			else
+				error("invalid param type")
+			end
+			message.set_colors(options.color)
+		end
+	},
+	includeonly = {
+		long = "includeonly",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.includeonly == nil, "multiple --includeonly options")
+			if param is string then
+				options.includeonly = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	make_depends = {
+		long = "make-depends",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.make_depends == nil, "multiple --make-depends options")
+			if param is string then
+				options.make_depends = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	print_output_directory = {
+		long = "print-output-directory",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.print_output_directory == nil, "multiple --print-output-directory options")
+			if param is string then
+				options.print_output_directory = true
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	package_support = {
+		long = "package-support",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			local known_packages:{string:boolean} = {["minted"] = true, ["epstopdf"] = true}
+			if param is string then
+				for pkg in string.gmatch(param, "[^,%s]+") do
+					options.package_support[pkg] = true
+					if not known_packages[pkg] and CLUTTEALTEX_VERBOSITY >= 1 then
+						message.warn("CluttealTeX provides no special support for '"..pkg.."'.")
+					end
+				end
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	check_driver = {
+		long = "check-driver",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.check_driver == nil, "multiple --check-driver options")
+			assert(param == "dvipdfmx" or param == "dvips" or param == "dvisvgm", "wrong value for --check-driver option")
+			if param is string then
+				options.check_driver = param
+			else
+				assert(param is string, "invalid param type")
+			end
+		end
+	},
+	-- Options for TeX
+	synctex = {
+		long = "synctex",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.synctex == nil, "multiple --synctex options")
+			if param is string then
+				options.synctex = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	file_line_error = {
+		long = "file-line-error",
+		boolean = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is boolean then
+				options.file_line_error = param
+			else
+				assert(param is string, "invalid param type")
+			end
+		end
+	},
+	interaction = {
+		long = "interaction",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.interaction == nil, "multiple --interaction options")
+			if param is string then
+				assert(param == "batchmode" or param == "nonstopmode" or param == "scrollmode" or param == "errorstopmode", "invalid argument for --interaction")
+				options.interaction = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	halt_on_error = {
+		long = "halt-on-error",
+		boolean = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is boolean then
+				options.halt_on_error = param
+			else
+				assert(param is string, "invalid param type")
+			end
+		end
+	},
+	shell_escape = {
+		long = "shell-escape",
+		boolean = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.shell_escape == nil and options.shell_restricted == nil, "multiple --(no-)shell-escape or --shell-restricted options")
+			if param is boolean then
+				options.shell_escape = param
+			else
+				assert(param is string, "invalid param type")
+			end
+		end
+	},
+	shell_restricted = {
+		long = "shell-restricted",
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.shell_escape == nil and options.shell_restricted == nil, "multiple --(no-)shell-escape or --shell-restricted options")
+			options.shell_restricted = true
+		end
+	},
+	jobname = {
+		long = "jobname",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.jobname == nil, "multiple --jobname options")
+			if param is string then
+				options.jobname = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	fmt = {
+		long = "fmt",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.fmt == nil, "multiple --fmt options")
+			if param is string then
+				options.fmt = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	output_directory = {
+		long = "output-directory",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.output_directory == nil, "multiple --output-directory options")
+			if param is string then
+				options.output_directory = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	output_format = {
+		long = "output-format",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.output_format == nil, "multiple --output-format options")
+			assert(param == "pdf" or param == "dvi", "invalid argument for --output-format")
+			if param is string then
+				options.output_format = param
+			else
+				assert(param is string, "invalid param type")
+			end
+		end
+	},
+	tex_option = {
+		long = "tex-option",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				table.insert(options.tex_extraoptions, shellutil.escape(param))
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	tex_options = {
+		long = "tex-options",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				table.insert(options.tex_extraoptions, param)
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	dvipdfmx_option = {
+		long = "dvipdfmx-option",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				table.insert(options.dvipdfmx_extraoptions, shellutil.escape(param))
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	dvipdfmx_options = {
+		long = "dvipdfmx-options",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				table.insert(options.dvipdfmx_extraoptions, param)
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	makeindex = {
+		long = "makeindex",
+		param = true,
+		default = "makeindex",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(not options.glossaries, "'makeindex' cannot be used together with 'glossaries'\nUse e.g. --glossaries='makeindex:main.ind:main.idx:main.ilg' instead of makeindex")
+			assert(options.makeindex == nil, "multiple --makeindex options")
+			if param is string then
+				options.makeindex = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	bibtex = {
+		long = "bibtex",
+		param = true,
+		default = "bibtex",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.bibtex == nil, "multiple --bibtex options")
+			assert(options.biber == nil, "multiple --bibtex/--biber options")
+			if param is string then
+				options.bibtex = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	biber = {
+		long = "biber",
+		param = true,
+		default = "biber",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.biber == nil, "multiple --biber options")
+			assert(options.bibtex == nil, "multiple --bibtex/--biber options")
+			if param is string then
+				options.biber = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	sagetex = {
+		long = "sagetex",
+		param = true,
+		default = "sage",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.sagetex == nil, "multiple --sagetex options")
+			if param is string then
+				options.sagetex = param
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	glossaries = {
+		long = "glossaries",
+		param = true,
+		default = "makeindex:main.glo:main.gls:main.glg",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(not options.makeindex, "'glossaries' cannot be used together with 'makeindex'\nUse e.g. --glossaries='makeindex:main.ind:main.idx:main.ilg' instead of makeindex")
+			if not options.glossaries then
+				options.glossaries = {}
+			end
+			if param is string then
+				local cfg = assert(parse_glossaries_option(param))
+				table.insert(options.glossaries, cfg)
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	memoize = {
+		long = "memoize",
+		param = true,
+		default = "perl",
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.memoize == nil, "multiple --memoize options")
+			if param is string then
+				if param == "python" then
+					options.memoize = "memoize-extract.py"
+				elseif param == "perl" then
+					options.memoize = "memoize-extract.pl"
+				else
+					options.memoize = param
+				end
+			else
+				error("invalid param type")
+			end
+		end
+	},
+	memoize_opt = {
+		long = "memoize_opt", -- TODO should be memoize-opt on commandline probably, but is breaking
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				options.memoize_opts = options.memoize_opts or {}
+				table.insert(options.memoize_opts, param)
+			else
+				error("invalid param type")
+			end
+		end
+	},
+}
+
+return {
+	spec = option_spec,
+	usage = usage,
+}

--- a/utils/build_cluttealtex.lua
+++ b/utils/build_cluttealtex.lua
@@ -77,6 +77,10 @@ local modules = {
 		path = "texrunner/handleoption.lua",
 	},
 	{
+		name = "texrunner.option_spec",
+		path = "texrunner/option_spec.lua",
+	},
+	{
 		name = "texrunner.isatty",
 		path = "texrunner/isatty.lua",
 	},


### PR DESCRIPTION
This is a preparation for #16. Doing this refactor I learnt that cluttex (and thus also cluttealtex) parses arguments which have a default value quite weird.
If default is set and parameter is specified as `--opt=param`, the parameter from the argument is taken.
If default is set and parameter is specified as `--opt param`, the default paramter is taken and the cli parameter is ignored (probably produces an error later during parsing).

The main part of the refactor was
1. move the `option_spec` to its own file
2. move handling the options inside the `option_spec` table
3. generate LUT to avoid having to iterate over the complete table

Now when adding a new option all that needs to be done is in the `option_spec.lua` file (adding the entry in the table and appending to the usage output).

Note: This will clash with #19