### PR TITLE
feat: read options from a config file

### DIFF
--- a/Makefile.cluttealtex
+++ b/Makefile.cluttealtex
@@ -18,6 +18,7 @@ sources= \
 		 src_lua/texrunner/recovery.lua \
 		 src_lua/texrunner/handleoption.lua \
 		 src_lua/texrunner/option_spec.lua \
+		 src_lua/texrunner/read_cfg.lua \
 		 src_lua/texrunner/isatty.lua \
 		 src_lua/texrunner/message.lua \
 		 src_lua/texrunner/fswatcher_windows.lua \

--- a/doc/cluttealtex.tex
+++ b/doc/cluttealtex.tex
@@ -368,4 +368,31 @@ Currently, the list of supported packages are \texpkg{graphics}, \texpkg{color},
 The check is always done with PDF mode.
 To check the driver with DVI mode, use \texttt{--check-driver} option.
 
+\section{Configuration file}
+When calling \CluttealTeX, it will search for a file named \verb|.cluttealtexrc.lua| in the current working directory. If it finds such a file, \CluttealTeX will load that lua file and use the tables defined there as configuration options. Options set via the cli will always have a higher priority and overwrite anything that was set via the configuration file.
+
+Note: The configuration file must return the table used to configure \CluttealTeX
+
+An example looks like this:
+\begin{verbatim}
+return {
+	options = {
+		file = "main.tex",
+		output_directory = "tex-aux",
+		change_directory = true,
+		engine = "pdflatex",
+		biber = true, -- uses the default value of biber
+		glossaries = {type="makeindex", out="acr", inp="acn", log="alg"}, -- could also be an array of these tables to configure multiple glossaries
+		max_iterations = "50",
+		quiet = "0",
+	},
+	defaults = {
+		watch = "inotify", -- changes the default value of this option. Only has an effect on cli arguments 
+	}
+}
+\end{verbatim}
+
+For now refer to \url{https://github.com/atticus-sullivan/cluttealtex/pull/22} for further details.
+The docs will be rewritten soon and this option described in more detail.
+
 \end{document}

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -35,6 +35,12 @@ end
 local KnownEngines = TexEngine.KnownEngines
 global CLUTTEALTEX_VERSION:string
 
+local record CfgOption
+	options: {string:any}
+	defaults: {string:string}
+	-- of course the handle_cli function is not type checked this way
+	add_cli_options: {string:table}
+end
 
 -- Default values for options
 local function set_default_values(options:options.Options)
@@ -87,42 +93,194 @@ local function query_short_options(name:string):Option,string,boolean
 	return option_spec[key], key, false
 end
 
+local function merge_options(...: options.Options): options.Options
+	local ret:{string:any} = {}
+	for _, i in ipairs{...} do
+		for k,v in pairs(i as {string:any}) do
+			ret[k] = v
+		end
+	end
+	return ret as options.Options
+end
+
 
 -- inputfile, engine, options = handle_cluttealtex_options(arg)
 local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine,options.Options
 	-- Store options
-	local options:options.Options = {
-		tex_extraoptions = {},
-		dvipdfmx_extraoptions = {},
-		package_support = {},
+	local var_options:{options.Options} = {
+		-- place one dummy option record in the array to ensure these fields
+		-- are defined as array even in case the user does not set these options
+		{
+			tex_extraoptions = {},
+			dvipdfmx_extraoptions = {},
+			package_support = {},
+		}
 	}
+	local inputfile:string
+
+		-- Parse options from config file
+	if fsutil.isfile(".cluttealtexrc.lua") then
+		local options:options.Options = {}
+		-- see https://ref.coddy.tech/lua/lua-sandboxing
+		-- for us the main purpose is to avoid the config modifies the
+		-- environment we're working in.
+		-- Apart from that restriction, the config is allowed to execute
+		-- anything.
+		-- local sandbox = {
+		-- 	print   = print,
+		-- 	-- Add other functions here
+		-- }
+		-- setmetatable(sandbox, {__index = function(t:table, k:any)
+		-- 	return error("Forbidden function/variable", 2) -- TODO(cfg) deep-copy from _G on demand instead
+		-- end})
+		-- TODO(cfg) move to a lua file to make use of _G (dynamically copy over/return on __index)
+		local cfgChunk, err = loadfile(".cluttealtexrc.lua")
+		if err then
+			message.error("Error loading the config file '.cluttealtexrc.lua'")
+			error(err)
+		end
+		local cfg = (function(): CfgOption
+			-- use a function for checking types of the config table
+			local cfg: any
+			cfg = cfgChunk()
+			if not (cfg is table) or cfg is nil then
+				message.error(".cluttealtexrc.lua needs to return a table with the configured options")
+				os.exit(1)
+			end
+			local cfg = cfg as table
+
+			local cfg_options = cfg.options
+			if not (cfg_options is {string: any} or cfg_options is nil) then
+				message.error(".cluttealtexrc.lua needs to return a table which contains an options key")
+				os.exit(1)
+			end
+
+			local cfg_defaults = cfg.defaults
+			if not (cfg_defaults is {string: string} or cfg_defaults is nil) then
+				message.error(".cluttealtexrc.lua needs to return a table which contains an defaults key")
+				os.exit(1)
+			end
+
+			local cfg_cli_options = cfg.cli_options
+			if not (cfg_cli_options is {string: table} or cfg_cli_options is nil) then
+				message.error(".cluttealtexrc.lua needs to return a table which contains an cli_options key")
+				os.exit(1)
+			end
+
+			return {
+					options=cfg_options as {string: any},
+					defaults=cfg_defaults as {string: string},
+					add_cli_options=cfg_cli_options as {string: table}
+				}
+		end)()
+
+		-- print(cfg.options)
+		-- print(cfg.defaults)
+		-- print(cfg.add_cli_options) -- of course the handle_cli function is not type checked this way
+
+		for optname, opt in pairs(cfg.options or {}) do
+			if optname == "file" then
+				assert(inputfile is nil, "multiple input files given")
+				if not opt is string then
+					message.error("parameter for 'file' must be a string in .cluttealtexrc.lua")
+					os.exit(1)
+				end
+				inputfile = opt as string
+			else
+				-- if the option passed was a not a table, simply use the same handler like for cli arguments
+				if option_spec[optname] then
+					-- to avoid copying the following, wrap opt in a simple array in case the option does not accumulate
+					-- to simplify passing a single value to an accumulating option, wrap the opt in that case as well
+					if not option_spec[optname].accumulate then
+						opt = {opt}
+					elseif not opt is table then
+						opt = {opt}
+					end
+					for _, opt in ipairs(opt as {any}) do
+						if type(opt) == "string" then
+							option_spec[optname].handle_cli(options, opt as string)
+						elseif type(opt) == "boolean" then
+							if not option_spec[optname].boolean and option_spec[optname].default then
+								option_spec[optname].handle_cli(options, option_spec[optname].default)
+							elseif option_spec[optname].boolean then
+								option_spec[optname].handle_cli(options, opt as boolean)
+							else
+								message.error(("option %s does not take a boolean"):format(optname))
+							end
+						elseif type(opt) == "table" then
+							if not option_spec[optname].handle_cfg then
+								message.error(("config for '%s' must not be a table"):format(optname))
+							else
+								option_spec[optname].handle_cfg(options, opt as table)
+							end
+						else
+							message.error(("config for '%s' must be either string, boolean or table in .cluttealtexrc.lua"):format(optname))
+							os.exit(1)
+						end
+					end
+				else
+					message.warn(("Option '%s' from .cluttealtexrc.lua unknown. Skipping that option"):format(optname))
+				end
+			end
+		end
+
+		for optname, default in pairs(cfg.defaults or {}) do
+			if option_spec[optname] then
+				option_spec[optname].default = default
+			else
+				message.warn(("Option '%s' from .cluttealtexrc.lua unknown. Not setting the default for this option"):format(optname))
+			end
+		end
+
+		for optname, opt in pairs(cfg.add_cli_options or {}) do
+			if option_spec[optname] then
+				message.warn(("In .cluttealtexrc.lua you're trying to define an optname (%s) which is already defined -> skipping it"):format(optname))
+			else
+				if not opt.handle_cli or (not opt.long and not opt.short) then
+					message.warn(("Options (%s) declared in .cluttealtexrc.lua must define the handle_cli function and at least have either long or short set -> skipping it"):format(optname))
+				else
+					option_spec[optname] = opt as Option
+				end
+			end
+		end
+		table.insert(var_options, options)
+	end
 
 	-- Parse options from commandline
 	local option_and_params, non_option_index = parseoption(arg, query_long_options, query_short_options)
 
 	-- Handle options
-	CLUTTEALTEX_VERBOSITY = 0
-	for _,option in ipairs(option_and_params) do
-		local optname:string = option[1]
-		local param:string|boolean = option[2]
-		assert(option_spec[optname], "invalid optname found").handle_cli(options, param)
+	do
+		local options:options.Options = {}
+		CLUTTEALTEX_VERBOSITY = 0
+		for _,option in ipairs(option_and_params) do
+			local optname:string = option[1]
+			local param:string|boolean = option[2]
+			assert(option_spec[optname], "invalid optname found").handle_cli(options, param)
+		end
+		table.insert(var_options, options)
 	end
+
+	local options = merge_options(table.unpack(var_options))
 
 	if options.color == nil then
 		message.set_colors("auto")
 	end
 
 	-- Handle non-options (i.e. input file)
-	if non_option_index > #arg then
+	print(inputfile, non_option_index, #arg)
+	if (inputfile and non_option_index <= #arg) or (not inputfile and non_option_index < #arg) then
+		message.error("Multiple input files are not supported.")
+		os.exit(1)
+	elseif not inputfile and non_option_index > #arg then
 		-- No input file given
 		usage(arg)
 		os.exit(1)
-	elseif non_option_index < #arg then
-		message.error("Multiple input files are not supported.")
-		os.exit(1)
+	elseif not inputfile then
+		inputfile = arg[non_option_index]
 	end
-	local inputfile = arg[non_option_index]
 
+	-- TODO(refactor) remove
 	-- If run as 'cllualatex', then the default engine is lualatex
 	if options.engine == nil and type(arg[0]) == "string" then
 		local basename = pathutil.trimext(pathutil.basename(arg[0]))
@@ -146,6 +304,10 @@ local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine
 
 	-- parameter validy check TODO should this be organized as function like
 	-- set_default_values and with a key in the option spec (list or function)?
+
+	-- TODO(refactor) EDIT(lukas): no probably make use of the option_spec for
+	-- this (add a new new function to which we pass the value set in the
+	-- options table)
 	if options.watch then
 		if options.watch ~= "fswatch" and options.watch ~= "inotifywait" then
 			message.error("Unknown wait engine '", options.watch, "'.")

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -200,7 +200,7 @@ local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine
 						if type(opt) == "string" then
 							option_spec[optname].handle_cli(options, opt as string)
 						elseif type(opt) == "boolean" then
-							if not option_spec[optname].boolean and option_spec[optname].default then
+							if not option_spec[optname].boolean and option_spec[optname].default and (opt as boolean) then
 								option_spec[optname].handle_cli(options, option_spec[optname].default)
 							elseif option_spec[optname].boolean then
 								option_spec[optname].handle_cli(options, opt as boolean)

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -160,10 +160,6 @@ local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine
 				}
 		end)()
 
-		-- print(cfg.options)
-		-- print(cfg.defaults)
-		-- print(cfg.add_cli_options) -- of course the handle_cli function is not type checked this way
-
 		for optname, opt in pairs(cfg.options or {}) do
 			if optname == "file" then
 				assert(inputfile is nil, "multiple input files given")
@@ -284,7 +280,6 @@ local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine
 	end
 
 	-- Handle non-options (i.e. input file)
-	print(inputfile, non_option_index, #arg)
 	if (inputfile and non_option_index <= #arg) or (not inputfile and non_option_index < #arg) then
 		message.error("Multiple input files are not supported.")
 		os.exit(1)

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -27,6 +27,7 @@ local message     = require "texrunner.message"
 local fsutil      = require "texrunner.fsutil"
 local option_spec = require "texrunner.option_spec".spec
 local usage = require "texrunner.option_spec".usage
+local read_cfg = require "texrunner.read_cfg".read_cfg
 
 local record Module
 	handle_cluttealtex_options: function({string}): string,TexEngine.Engine,options.Options
@@ -121,28 +122,13 @@ local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine
 		-- Parse options from config file
 	if fsutil.isfile(".cluttealtexrc.lua") then
 		local options:options.Options = {}
-		-- see https://ref.coddy.tech/lua/lua-sandboxing
-		-- for us the main purpose is to avoid the config modifies the
-		-- environment we're working in.
-		-- Apart from that restriction, the config is allowed to execute
-		-- anything.
-		-- local sandbox = {
-		-- 	print   = print,
-		-- 	-- Add other functions here
-		-- }
-		-- setmetatable(sandbox, {__index = function(t:table, k:any)
-		-- 	return error("Forbidden function/variable", 2) -- TODO(cfg) deep-copy from _G on demand instead
-		-- end})
-		-- TODO(cfg) move to a lua file to make use of _G (dynamically copy over/return on __index)
-		local cfgChunk, err = loadfile(".cluttealtexrc.lua")
-		if err then
-			message.error("Error loading the config file '.cluttealtexrc.lua'")
-			error(err)
-		end
 		local cfg = (function(): CfgOption
 			-- use a function for checking types of the config table
-			local cfg: any
-			cfg = cfgChunk()
+			local cfg, err = read_cfg(".cluttealtexrc.lua")
+			if err or not cfg then
+				message.error("Error during reading the .cluttealtexrc.lua file: "..(err or ""))
+					os.exit(1)
+			end
 			if not (cfg is table) or cfg is nil then
 				message.error(".cluttealtexrc.lua needs to return a table with the configured options")
 				os.exit(1)

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -198,12 +198,30 @@ local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine
 					end
 					for _, opt in ipairs(opt as {any}) do
 						if type(opt) == "string" then
-							option_spec[optname].handle_cli(options, opt as string)
+							local o = option_spec[optname]
+							if o.handle_cli then
+								o.handle_cli(options, opt as string)
+							else
+								message.error(("%s needs to be set via a table in the config file"):format(optname))
+								os.exit(1)
+							end
 						elseif type(opt) == "boolean" then
 							if not option_spec[optname].boolean and option_spec[optname].default and (opt as boolean) then
-								option_spec[optname].handle_cli(options, option_spec[optname].default)
+								local o = assert(option_spec[optname])
+								if o.handle_cli then
+									o.handle_cli(options, option_spec[optname].default)
+								else
+									message.error(("%s needs to be set via a table in the config file"):format(optname))
+									os.exit(1)
+								end
 							elseif option_spec[optname].boolean then
-								option_spec[optname].handle_cli(options, opt as boolean)
+								local o = assert(option_spec[optname])
+								if o.handle_cli then
+									o.handle_cli(options, opt as boolean)
+								else
+									message.error(("%s needs to be set via a table in the config file"):format(optname))
+									os.exit(1)
+								end
 							else
 								message.error(("option %s does not take a boolean"):format(optname))
 							end
@@ -211,7 +229,13 @@ local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine
 							if not option_spec[optname].handle_cfg then
 								message.error(("config for '%s' must not be a table"):format(optname))
 							else
-								option_spec[optname].handle_cfg(options, opt as table)
+								local o = assert(option_spec[optname])
+								if o.handle_cli then
+									o.handle_cfg(options, opt as table)
+								else
+									message.error(("%s needs to be set either as boolean/string in the config or as cli argument"):format(optname))
+									os.exit(1)
+								end
 							end
 						else
 							message.error(("config for '%s' must be either string, boolean or table in .cluttealtexrc.lua"):format(optname))
@@ -256,7 +280,13 @@ local function handle_cluttealtex_options(arg:{string}): string,TexEngine.Engine
 		for _,option in ipairs(option_and_params) do
 			local optname:string = option[1]
 			local param:string|boolean = option[2]
-			assert(option_spec[optname], "invalid optname found").handle_cli(options, param)
+			local o = assert(option_spec[optname], "invalid optname found")
+			if o.handle_cli then
+				o.handle_cli(options, param)
+			else
+				message.error(("%s can only be set as a table via the config file"):format(optname))
+				os.exit(1)
+			end
 		end
 		table.insert(var_options, options)
 	end

--- a/src_teal/texrunner/option.tl
+++ b/src_teal/texrunner/option.tl
@@ -25,7 +25,9 @@ local record Option
 	allow_single_hyphen: boolean
 	default: string
 	boolean: boolean
+	accumulate: boolean
 	handle_cli: function({string:any}, string|boolean)
+	handle_cfg: function({string:any}, table)
 end
 
 -- options_and_params, i = parseoption(arg, options)

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -47,41 +47,36 @@ local function split(opt:string): {string}
 	return ret
 end
 
-local function parse_glossaries_option(opt:string): options.Glos, string
-	local s = split(opt)
-	if #s < 2 or #s > 6 then
-		return nil, "Error on splitting the glossaries parameter \""..opt.."\""
-	end
-
+local function parse_glossaries_option_from_table(opt:{string:string|nil}): options.Glos, string
 	local ret:options.Glos = {}
 
-	ret.type = s[1]
-	if ret.type ~= "makeindex" and ret.type ~= "xindy" and (#s ~= 7 or s[5] == "") then
+	ret.type = opt.type
+	if not (ret.type == "makeindex" or ret.type == "xindy" or (opt.path and opt.path ~= "")) then
 		return nil, "Invalid glossaries parameter. \""..ret.type.."\" is unsupported"
 	end
 
-	ret.out = s[2]
+	ret.out = opt.out
 
-	if #s >= 3 and s[3] ~= "" then
-		ret.inp = s[3]
+	if opt.inp and opt.inp ~= "" then
+		ret.inp = opt.inp
 	else
 		ret.inp = ret.out:sub(1,-2).."o"
 	end
 
-	if #s >= 4 and s[4] ~= "" then
-		ret.log = s[4]
+	if opt.log and opt.log ~= "" then
+		ret.log = opt.log
 	else
 		ret.log = ret.out:sub(1,-2).."g"
 	end
 
-	if #s >= 5 and s[5] ~= "" then
-		ret.path = s[5]
+	if opt.path and opt.path ~= "" then
+		ret.path = opt.path
 	else
 		ret.path = ret.type
 	end
 
-	if #s >= 6 then
-		ret.cmd = function(path_in_output_directory: function(ext:string):string):string return ret.path.." "..s[6] end
+	if opt.cmd_args then
+		ret.cmd = function(path_in_output_directory: function(ext:string):string):string return ret.path.." "..opt.cmd_args end
 	else
 		local foo = "%s.%s"
 		if ret.type == "makeindex" then
@@ -103,11 +98,19 @@ local function parse_glossaries_option(opt:string): options.Glos, string
 				)
 			end
 		else
-			return nil, "Error on parsing the glossaries parameter \""..opt.."\""
+			return nil, "Error on parsing the glossaries parameter"
 		end
 	end
 
 	return ret
+end
+
+local function parse_glossaries_option_from_string(opt:string): options.Glos, string
+	local s = split(opt)
+	if #s < 2 or #s > 6 then
+		return nil, "Error on splitting the glossaries parameter \""..opt.."\""
+	end
+	return parse_glossaries_option_from_table{type=s[1], out=s[2], inp=s[3], log=s[4], path=s[5], cmd_args=s[6]}
 end
 
 local function usage(arg:{string})
@@ -231,7 +234,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	engine_executable = {
 		long = "engine-executable",
@@ -243,7 +246,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	output = {
 		short = "o",
@@ -256,7 +259,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	fresh = {
 		long = "fresh",
@@ -267,7 +270,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	max_iterations = {
 		long = "max-iterations",
@@ -276,21 +279,21 @@ local option_spec:{string:Option} = {
 			assert(options.max_iterations == nil, "multiple --max-iterations options")
 			options.max_iterations = assert(tonumber(param) as integer, "invalid value for --max-iterations option")
 			assert(options.max_iterations >= 1, "invalid value for --max-iterations option")
-		end
+		end,
 	},
 	skip_first = {
 		long = "skip-first",
 		handle_cli = function(options:options.Options, param:string|boolean)
 			assert(options.skip_first == nil, "multiple --skip-first options")
 			options.skip_first = true
-		end
+		end,
 	},
 	start_with_draft = {
 		long = "start-with-draft",
 		handle_cli = function(options:options.Options, param:string|boolean)
 			assert(options.start_with_draft == nil, "multiple --start-with-draft options")
 			options.start_with_draft = true
-		end
+		end,
 	},
 	change_directory = {
 		long = "change-directory",
@@ -302,7 +305,7 @@ local option_spec:{string:Option} = {
 					else
 					error("invalid param type")
 				end
-			end
+			end,
 	},
 	watch = {
 		long = "watch",
@@ -315,55 +318,55 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	watch_only_path = {
 		long = "watch-only-path",
 		param = true,
 		handle_cli = function(options:options.Options, param:string|boolean)
 			if param is string then
-				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				options.watch_inc_exc = options.watch_inc_exc or {}
 				table.insert(options.watch_inc_exc, {param=pathutil.abspath(param),type='only_path'})
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	watch_not_path = {
 		long = "watch-not-path",
 		param = true,
 		handle_cli = function(options:options.Options, param:string|boolean)
 			if param is string then
-				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				options.watch_inc_exc = options.watch_inc_exc or {}
 				table.insert(options.watch_inc_exc, {param=pathutil.abspath(param),type='not_path'})
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	watch_only_ext = {
 		long = "watch-only-ext",
 		param = true,
 		handle_cli = function(options:options.Options, param:string|boolean)
 			if param is string then
-				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				options.watch_inc_exc = options.watch_inc_exc or {}
 				table.insert(options.watch_inc_exc, {param=param,type='only_ext'})
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	watch_not_ext = {
 		long = "watch-not-ext",
 		param = true,
 		handle_cli = function(options:options.Options, param:string|boolean)
 			if param is string then
-				if not options.watch_inc_exc then options.watch_inc_exc = {} end
+				options.watch_inc_exc = options.watch_inc_exc or {}
 				table.insert(options.watch_inc_exc, {param=param,type='not_ext'})
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	help = {
 		short = "h",
@@ -372,7 +375,7 @@ local option_spec:{string:Option} = {
 		handle_cli = function(options:options.Options, param:string|boolean)
 			usage(arg)
 			os.exit(0)
-		end
+		end,
 	},
 	version = {
 		short = "v",
@@ -380,14 +383,14 @@ local option_spec:{string:Option} = {
 		handle_cli = function(options:options.Options, param:string|boolean)
 			io.stderr:write("cluttealtex ",CLUTTEALTEX_VERSION,"\n")
 			os.exit(0)
-		end
+		end,
 	},
 	verbose = {
 		short = "V",
 		long = "verbose",
 		handle_cli = function(options:options.Options, param:string|boolean)
 			CLUTTEALTEX_VERBOSITY = CLUTTEALTEX_VERBOSITY + 1
-		end
+		end,
 	},
 	color = {
 		long = "color",
@@ -401,7 +404,7 @@ local option_spec:{string:Option} = {
 				error("invalid param type")
 			end
 			message.set_colors(options.color)
-		end
+		end,
 	},
 	includeonly = {
 		long = "includeonly",
@@ -413,7 +416,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	make_depends = {
 		long = "make-depends",
@@ -425,7 +428,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	print_output_directory = {
 		long = "print-output-directory",
@@ -436,7 +439,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	package_support = {
 		long = "package-support",
@@ -453,7 +456,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	check_driver = {
 		long = "check-driver",
@@ -466,177 +469,7 @@ local option_spec:{string:Option} = {
 			else
 				assert(param is string, "invalid param type")
 			end
-		end
-	},
-	-- Options for TeX
-	synctex = {
-		long = "synctex",
-		param = true,
-		allow_single_hyphen = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			assert(options.synctex == nil, "multiple --synctex options")
-			if param is string then
-				options.synctex = param
-			else
-				error("invalid param type")
-			end
-		end
-	},
-	file_line_error = {
-		long = "file-line-error",
-		boolean = true,
-		allow_single_hyphen = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			if param is boolean then
-				options.file_line_error = param
-			else
-				assert(param is string, "invalid param type")
-			end
-		end
-	},
-	interaction = {
-		long = "interaction",
-		param = true,
-		allow_single_hyphen = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			assert(options.interaction == nil, "multiple --interaction options")
-			if param is string then
-				assert(param == "batchmode" or param == "nonstopmode" or param == "scrollmode" or param == "errorstopmode", "invalid argument for --interaction")
-				options.interaction = param
-			else
-				error("invalid param type")
-			end
-		end
-	},
-	halt_on_error = {
-		long = "halt-on-error",
-		boolean = true,
-		allow_single_hyphen = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			if param is boolean then
-				options.halt_on_error = param
-			else
-				assert(param is string, "invalid param type")
-			end
-		end
-	},
-	shell_escape = {
-		long = "shell-escape",
-		boolean = true,
-		allow_single_hyphen = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			assert(options.shell_escape == nil and options.shell_restricted == nil, "multiple --(no-)shell-escape or --shell-restricted options")
-			if param is boolean then
-				options.shell_escape = param
-			else
-				assert(param is string, "invalid param type")
-			end
-		end
-	},
-	shell_restricted = {
-		long = "shell-restricted",
-		allow_single_hyphen = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			assert(options.shell_escape == nil and options.shell_restricted == nil, "multiple --(no-)shell-escape or --shell-restricted options")
-			options.shell_restricted = true
-		end
-	},
-	jobname = {
-		long = "jobname",
-		param = true,
-		allow_single_hyphen = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			assert(options.jobname == nil, "multiple --jobname options")
-			if param is string then
-				options.jobname = param
-			else
-				error("invalid param type")
-			end
-		end
-	},
-	fmt = {
-		long = "fmt",
-		param = true,
-		allow_single_hyphen = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			assert(options.fmt == nil, "multiple --fmt options")
-			if param is string then
-				options.fmt = param
-			else
-				error("invalid param type")
-			end
-		end
-	},
-	output_directory = {
-		long = "output-directory",
-		param = true,
-		allow_single_hyphen = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			assert(options.output_directory == nil, "multiple --output-directory options")
-			if param is string then
-				options.output_directory = param
-			else
-				error("invalid param type")
-			end
-		end
-	},
-	output_format = {
-		long = "output-format",
-		param = true,
-		allow_single_hyphen = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			assert(options.output_format == nil, "multiple --output-format options")
-			assert(param == "pdf" or param == "dvi", "invalid argument for --output-format")
-			if param is string then
-				options.output_format = param
-			else
-				assert(param is string, "invalid param type")
-			end
-		end
-	},
-	tex_option = {
-		long = "tex-option",
-		param = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			if param is string then
-				table.insert(options.tex_extraoptions, shellutil.escape(param))
-			else
-				error("invalid param type")
-			end
-		end
-	},
-	tex_options = {
-		long = "tex-options",
-		param = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			if param is string then
-				table.insert(options.tex_extraoptions, param)
-			else
-				error("invalid param type")
-			end
-		end
-	},
-	dvipdfmx_option = {
-		long = "dvipdfmx-option",
-		param = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			if param is string then
-				table.insert(options.dvipdfmx_extraoptions, shellutil.escape(param))
-			else
-				error("invalid param type")
-			end
-		end
-	},
-	dvipdfmx_options = {
-		long = "dvipdfmx-options",
-		param = true,
-		handle_cli = function(options:options.Options, param:string|boolean)
-			if param is string then
-				table.insert(options.dvipdfmx_extraoptions, param)
-			else
-				error("invalid param type")
-			end
-		end
+		end,
 	},
 	makeindex = {
 		long = "makeindex",
@@ -650,7 +483,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	bibtex = {
 		long = "bibtex",
@@ -664,7 +497,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	biber = {
 		long = "biber",
@@ -678,7 +511,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	sagetex = {
 		long = "sagetex",
@@ -691,7 +524,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	glossaries = {
 		long = "glossaries",
@@ -703,12 +536,49 @@ local option_spec:{string:Option} = {
 				options.glossaries = {}
 			end
 			if param is string then
-				local cfg = assert(parse_glossaries_option(param))
-				table.insert(options.glossaries, cfg)
+				options.glossaries = options.glossaries or {}
+				table.insert(options.glossaries, assert(parse_glossaries_option_from_string(param)))
 			else
 				error("invalid param type")
 			end
-		end
+		end,
+		handle_cfg = function(options:options.Options, param: table)
+			local param = (function(): {string:string|nil}
+				local inp = param.inp
+				if not inp is string and not inp is nil then
+					return
+				end
+
+				local t = param.type
+				if not t is string and not t is nil then
+					return
+				end
+
+				local out = param.out
+				if not out is string and not out is nil then
+					return
+				end
+
+				local path = param.path
+				if not path is string and not path is nil then
+					return
+				end
+
+				local cmd = param.cmd
+				if not cmd is string and not cmd is nil then
+					return
+				end
+
+				local log = param.log
+				if not log is string and not log is nil then
+					return
+				end
+				return {type=t, out=out, inp=inp, log=log, path=path, cmd=cmd}
+			end)()
+
+			options.glossaries = options.glossaries or {}
+			table.insert(options.glossaries, assert(parse_glossaries_option_from_table(param)))
+		end,
 	},
 	memoize = {
 		long = "memoize",
@@ -727,7 +597,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	memoize_opt = {
 		long = "memoize_opt", -- TODO should be memoize-opt on commandline probably, but is breaking
@@ -739,7 +609,7 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
 	},
 	quiet = {
 		long = "quiet",
@@ -752,7 +622,181 @@ local option_spec:{string:Option} = {
 			else
 				error("invalid param type")
 			end
-		end
+		end,
+	},
+	-- Options for TeX
+	synctex = {
+		long = "synctex",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.synctex == nil, "multiple --synctex options")
+			if param is string then
+				options.synctex = param
+			else
+				error("invalid param type")
+			end
+		end,
+	},
+	file_line_error = {
+		long = "file-line-error",
+		boolean = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is boolean then
+				options.file_line_error = param
+			else
+				assert(param is string, "invalid param type")
+			end
+		end,
+	},
+	interaction = {
+		long = "interaction",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.interaction == nil, "multiple --interaction options")
+			if param is string then
+				assert(param == "batchmode" or param == "nonstopmode" or param == "scrollmode" or param == "errorstopmode", "invalid argument for --interaction")
+				options.interaction = param
+			else
+				error("invalid param type")
+			end
+		end,
+	},
+	halt_on_error = {
+		long = "halt-on-error",
+		boolean = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is boolean then
+				options.halt_on_error = param
+			else
+				assert(param is string, "invalid param type")
+			end
+		end,
+	},
+	shell_escape = {
+		long = "shell-escape",
+		boolean = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.shell_escape == nil and options.shell_restricted == nil, "multiple --(no-)shell-escape or --shell-restricted options")
+			if param is boolean then
+				options.shell_escape = param
+			else
+				assert(param is string, "invalid param type")
+			end
+		end,
+	},
+	shell_restricted = {
+		long = "shell-restricted",
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.shell_escape == nil and options.shell_restricted == nil, "multiple --(no-)shell-escape or --shell-restricted options")
+			options.shell_restricted = true
+		end,
+	},
+	jobname = {
+		long = "jobname",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.jobname == nil, "multiple --jobname options")
+			if param is string then
+				options.jobname = param
+			else
+				error("invalid param type")
+			end
+		end,
+	},
+	fmt = {
+		long = "fmt",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.fmt == nil, "multiple --fmt options")
+			if param is string then
+				options.fmt = param
+			else
+				error("invalid param type")
+			end
+		end,
+	},
+	output_directory = {
+		long = "output-directory",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.output_directory == nil, "multiple --output-directory options")
+			if param is string then
+				options.output_directory = param
+			else
+				error("invalid param type")
+			end
+		end,
+	},
+	output_format = {
+		long = "output-format",
+		param = true,
+		allow_single_hyphen = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			assert(options.output_format == nil, "multiple --output-format options")
+			assert(param == "pdf" or param == "dvi", "invalid argument for --output-format")
+			if param is string then
+				options.output_format = param
+			else
+				assert(param is string, "invalid param type")
+			end
+		end,
+	},
+	tex_option = {
+		long = "tex-option",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				options.tex_extraoptions = options.tex_extraoptions or {}
+				table.insert(options.tex_extraoptions, shellutil.escape(param))
+			else
+				error("invalid param type")
+			end
+		end,
+	},
+	tex_options = {
+		long = "tex-options",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				options.tex_extraoptions = options.tex_extraoptions or {}
+				table.insert(options.tex_extraoptions, param)
+			else
+				error("invalid param type")
+			end
+		end,
+	},
+	dvipdfmx_option = {
+		long = "dvipdfmx-option",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				options.dvipdfmx_extraoptions = options.dvipdfmx_extraoptions or {}
+				table.insert(options.dvipdfmx_extraoptions, shellutil.escape(param))
+			else
+				error("invalid param type")
+			end
+		end,
+	},
+	dvipdfmx_options = {
+		long = "dvipdfmx-options",
+		param = true,
+		handle_cli = function(options:options.Options, param:string|boolean)
+			if param is string then
+				options.dvipdfmx_extraoptions = options.dvipdfmx_extraoptions or {}
+				table.insert(options.dvipdfmx_extraoptions, param)
+			else
+				error("invalid param type")
+			end
+		end,
 	},
 }
 

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -1,8 +1,4 @@
 local record Module
-	record Options_glos
-		out:string
-		inp: string
-	end
 	record Options
 		biber: string
 		bibtex: string

--- a/src_teal/texrunner/read_cfg.d.tl
+++ b/src_teal/texrunner/read_cfg.d.tl
@@ -1,0 +1,5 @@
+local record read_cfg
+	read_cfg: function(path: string): any, string
+end
+
+return read_cfg

--- a/src_teal/texrunner/read_cfg.lua
+++ b/src_teal/texrunner/read_cfg.lua
@@ -1,0 +1,67 @@
+--[[
+  Copyright 2018 ARATA Mizuki
+  Copyright 2024 Lukas Heindl
+
+  This file is part of CluttealTeX.
+
+  CluttealTeX is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  CluttealTeX is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
+]]
+
+local function deep_copy(x)
+	if type(x) == "table" then
+		local r = {}
+		for k,v in pairs(x) do
+			r[k] = deep_copy(v)
+		end
+		return r
+	else
+		return x
+	end
+end
+
+-- safely read the file at path as config file
+-- Goal: Run config file without imposing restrictions to the config file
+-- (it is allowed to contain any code). But guard the global environment
+-- from being modified by the config file.
+--
+-- In order to do this, when the there is an access to the global environment,
+-- the required part of the environment is (deep) copied over to the environment
+-- of the config file on demand.
+-- Of course this might consume some memory, but usually the global environment
+-- is not that large and also there should only be one config that is read on
+-- startup.
+--
+-- Note: This does not ensure confidentiality, only integrity
+--
+-- Concept from https://ref.coddy.tech/lua/lua-sandboxing
+local function read_cfg(path)
+	local sandbox = {}
+	setmetatable(sandbox, {__index = function(t, k)
+		if _G[k] then
+			t[k] = deep_copy(_G[k])
+			return t[k]
+		end
+		return nil
+	end})
+
+	local cfgChunk, err = loadfile(path, "t", sandbox)
+	if not cfgChunk or err then
+		return "Error loading the config file '.cluttealtexrc.lua': "..(err or "")
+	end
+	return cfgChunk()
+end
+
+return {
+	read_cfg = read_cfg,
+}

--- a/utils/build_cluttealtex.lua
+++ b/utils/build_cluttealtex.lua
@@ -81,6 +81,10 @@ local modules = {
 		path = "texrunner/option_spec.lua",
 	},
 	{
+		name = "texrunner.read_cfg",
+		path = "texrunner/read_cfg.lua",
+	},
+	{
 		name = "texrunner.isatty",
 		path = "texrunner/isatty.lua",
 	},


### PR DESCRIPTION
This PR adds the feature that a `.cluttealtexrc.lua` from the current pwd is always read in order to define some options.

An example config could look like this:
```lua
return {
	options = {
		file = "main.tex",
		output_directory = "tex-aux",
		change_directory = true,
		engine = "pdflatex",
		biber = true, -- uses the default value of biber
		glossaries = {type="makeindex", out="acr", inp="acn", log="alg"}, -- could also be an array of these tables to configure multiple glossaries
		max_iterations = "50",
		quiet = "0",
	},
	defaults = {
		watch = "inotify", -- changes the default value of this option. Only has an effect on cli arguments 
	}
}
```

Notes:
- `options` table takes all `optnames` that are also parsed from the cli if the value is a string or boolean.
- if a boolean passed to an option that takes a default value this leads to the default value being internally passed to that option
- cli options always have a higher priority than config options. When reading the options, we build distinct tables for both configuration methods and merge them in the end. Merging works as simple as if key defined via cli, overwrite everything the config file configured for that key.

Also you can use the config file to change default values (see the example) and define new arguments. For the latter you can have a look how options are defined in the `option_spec.tl` (or the `Option` record definition in `option.tl`), your new option should follow this pattern.

TODOs:
- [x] `handle_cli` or `handle_cfg` might be `nil` catch this and write a nice error message to use the other configuration method.
- [x] mention this feature in the docs
- [x] read the config file in a (leaky) sandbox