### PR TITLE
fixup: ref to os.execute in shellutil

### DIFF
--- a/src_teal/texrunner/shellutil_unix.tl
+++ b/src_teal/texrunner/shellutil_unix.tl
@@ -18,12 +18,13 @@
   along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
-local assert = assert
+local os           = require"os_"
+local assert       = assert
 local string_match = string.match
-local table = table
+local table        = table
 local table_insert = table.insert
 local table_concat = table.concat
-local os_execute = os.execute
+local os_execute   = os.execute
 
 -- s: string
 local function escape(s: string): string
@@ -60,8 +61,8 @@ assert(escape([[Hello' world!"]]) == [['Hello'"'"' world!"']])
 -- END TEST CODE
 
 local function has_command(name: string): boolean
-  local result = os_execute("which " .. escape(name) .. " > /dev/null")
-  return result
+	local result = os_execute("which " .. escape(name) .. " > /dev/null 2>/dev/null")
+	return result == 0
 end
 
 return {

--- a/src_teal/texrunner/shellutil_windows.tl
+++ b/src_teal/texrunner/shellutil_windows.tl
@@ -18,6 +18,7 @@
   along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
+local os = require"os_"
 local string_gsub = string.gsub
 local os_execute = os.execute
 
@@ -33,7 +34,7 @@ assert(escape([[Hello\" world!"]]) == [["Hello\\\" world!\""]])
 
 local function has_command(name: string): boolean
   local result = os_execute("where " .. escape(name) .. " > NUL 2>&1")
-  return result
+  return result == 0
 end
 
 return {


### PR DESCRIPTION
`shellutil` did directly use the `os` library without the `os_.d.tl` wrapper which provides the `texlua` version of the `os` library. Thus, the returned value was handled incorrectly which is now fixed in this PR.

Also the `stderr` on `has_command` is now silenced in the unix version of `shellutil` as well.