### PR TITLE
Implement basic hooking mechanism

### DIFF
--- a/specs/handleoption.lua
+++ b/specs/handleoption.lua
@@ -241,7 +241,9 @@ describe("handleoption", function()
 					log="xyg",
 					path="makeindex",
 					cmd=options.glossaries[1].cmd, -- ignore the function
-				}}})
+				}},
+				hooks=options.hooks, -- ignore the hooks for now
+				})
 			end)
 
 			-- Test handling an unknown type
@@ -368,6 +370,7 @@ describe("handleoption", function()
 				glossaries = {{type="makeindex", path="makeindex", out="acr", inp="acn", log="alg", cmd=options.glossaries[1].cmd}},
 				max_iterations = 50,
 				quiet = 0,
+				hooks = options.hooks, -- ignore the hooks for now
 			})
 			expect.equal(inputfile, "main.tex")
 			local watch = handleoption._internal.query_options("watch", "long")

--- a/specs/handleoption.lua
+++ b/specs/handleoption.lua
@@ -37,6 +37,30 @@ describe("handleoption", function()
 		end)
 	end)
 
+	describe("merge_hook_type", function()
+		-- Test merging suggestion hooks
+		it("merges suggestion hooks correctly", function()
+			local hooks = { suggestion_hooks = { [1.1] = "hook1", [2] = "hook2" } }
+			local hs = { [1.1] = "hook1" } -- Only hook1 should remain
+			local ret = { hooks = hooks }
+
+			handleoption._internal.merge_hook_type("suggestion_hooks", hs, ret)
+
+			expect.equal(ret.hooks.suggestion_hooks, { [1.1] = "hook1" })
+		end)
+
+		-- Test merging hooks that are not suggestions
+		it("merges non-suggestion hooks correctly", function()
+			local hooks = { other_hooks = {[3] = "old_hook", [4] = "hook4"} }
+			local hs = { [3] = "hook3" }
+			local ret = { hooks = hooks }
+
+			handleoption._internal.merge_hook_type("other_hooks", hs, ret)
+
+			expect.equal(ret.hooks.other_hooks, { [3] = "hook3", [4] = "hook4" })
+		end)
+	end)
+
 	describe("merge_options", function()
 		-- Test for merge_options function
 		it("should correctly merge two option tables", function()
@@ -47,6 +71,28 @@ describe("handleoption", function()
 			expect.equal(merged_options.tex_extraoptions, {"opt3", "opt4"})
 			expect.equal(merged_options.max_iterations, 3)
 			expect.equal(merged_options.skip_first, false)
+		end)
+
+		-- Test merging options with hooks
+		it("correctly merges options including hooks", function()
+			local options1 = {
+				tex_extraoptions = {"opt1", "opt2"},
+				hooks = { suggestion_hooks = { [1] = "hook1" }, other_hooks = {} },
+			}
+			local options2 = {
+				tex_extraoptions = {"opt3", "opt4"},
+				hooks = { suggestion_hooks = { [1] = "hook1", [2] = "hook2" }, other_hooks = { [3] = "hook3" } },
+			}
+
+			local merged_options = handleoption._internal.merge_options(options1, options2)
+
+			expect.equal(merged_options, {
+				tex_extraoptions = {"opt3", "opt4"},
+				hooks = {
+					suggestion_hooks = {[1]="hook1"},
+					other_hooks = {[3]="hook3"},
+				},
+			})
 		end)
 	end)
 

--- a/specs/init.lua
+++ b/specs/init.lua
@@ -14,6 +14,7 @@ require 'specs.read_cfg'
 require 'specs.utils'
 require 'specs.watcher'
 require 'specs.option_spec'
+require 'specs.typeset_hooks'
 
 lester.report() -- Print overall statistic of the tests run.
 lester.exit() -- Exit with success if all tests passed.

--- a/specs/init.lua
+++ b/specs/init.lua
@@ -13,6 +13,7 @@ require 'specs.tex_engine'
 require 'specs.read_cfg'
 require 'specs.utils'
 require 'specs.watcher'
+require 'specs.option_spec'
 
 lester.report() -- Print overall statistic of the tests run.
 lester.exit() -- Exit with success if all tests passed.

--- a/specs/option_spec.lua
+++ b/specs/option_spec.lua
@@ -21,6 +21,7 @@ describe("option_spec", function()
 					post_compile = {},
 					suggestion_file_based = {},
 					suggestion_execlog_based = {},
+					post_build = {},
 				}
 			})
 		end)

--- a/specs/option_spec.lua
+++ b/specs/option_spec.lua
@@ -1,0 +1,131 @@
+local lester = require 'lester'
+
+local describe = lester.describe
+local it       = lester.it
+local expect   = lester.expect
+
+CLUTTEALTEX_VERBOSITY = 0
+CLUTTEALTEX_TEST_ENV  = true
+
+local option_spec = require 'src_lua.texrunner.option_spec'
+
+describe("option_spec", function()
+	describe("init_hooks", function()
+		it("initializes hooks with empty tables", function()
+			local options = {}
+			local spec = {}
+			option_spec.init_hooks(options, spec)
+			expect.equal(options, {
+				hooks = {
+					tex_injection = {},
+					post_compile = {},
+					suggestion_file_based = {},
+					suggestion_execlog_based = {},
+				}
+			})
+		end)
+
+		it("invokes suggestion handlers if specified in the spec", function()
+			local called = {file_based = false, execlog_based = false}
+			local options = {}
+			local spec = {
+				optionA = {
+					suggestion_handlers = {
+						file_based = function(_) called.file_based = true end,
+						execlog_based = function(_) called.execlog_based = true end,
+					}
+				}
+			}
+			option_spec.init_hooks(options, spec)
+			expect.truthy(called.file_based)
+			expect.truthy(called.execlog_based)
+		end)
+	end)
+
+	describe("split", function()
+		it("splits a string with unescaped delimiters", function()
+			local result = option_spec._internal.split("a:b:c")
+			expect.equal(result, {"a", "b", "c"})
+		end)
+
+		it("handles escaped delimiters correctly", function()
+			local result = option_spec._internal.split("a\\:b:c")
+			expect.equal(result, {"a:b", "c"})
+		end)
+
+		it("handles trailing characters correctly", function()
+			local result = option_spec._internal.split("a:b:c\\")
+			expect.equal(result, {"a", "b", "c"})
+		end)
+	end)
+
+	describe("parse_glossaries_option_from_table", function()
+		it("parses a valid glossaries table with default values", function()
+			local input = {type = "makeindex", out = "output.idx"}
+			local result, err = option_spec._internal.parse_glossaries_option_from_table(input)
+			expect.not_exist(err)
+			expect.equal(result, {
+				type = "makeindex",
+				out  = "output.idx",
+				inp  = "output.ido",
+				log  = "output.idg",
+				path = "makeindex",
+				cmd  = result.cmd, -- don't check function
+			})
+		end)
+
+		it("returns an error for invalid types", function()
+			local input = {type = "unsupported", out = "output.idx"}
+			local result, err = option_spec._internal.parse_glossaries_option_from_table(input)
+			expect.not_exist(result)
+			expect.exist(err)
+			expect.equal(err, 'Invalid glossaries parameter. "unsupported" is unsupported')
+		end)
+
+		it("returns an error if 'out' is not set", function()
+			local input = {type = "makeindex"}
+			local result, err = option_spec._internal.parse_glossaries_option_from_table(input)
+			expect.not_exist(result)
+			expect.exist(err)
+			expect.equal(err, "'out' must be set")
+		end)
+	end)
+
+	describe("parse_glossaries_option_from_string", function()
+		it("parses a valid glossaries string", function()
+			local input = "makeindex:output.idx:input.ido:logfile.log:mycustompath"
+			local result, err = option_spec._internal.parse_glossaries_option_from_string(input)
+			expect.not_exist(err)
+			expect.equal(result, {
+				type = "makeindex",
+				out  = "output.idx",
+				inp  = "input.ido",
+				log  = "logfile.log",
+				cmd  = result.cmd, -- don't check function
+				path = "mycustompath",
+			})
+		end)
+
+		it("returns an error for invalid glossaries strings", function()
+			local input = "makeindex"
+			local result, err = option_spec._internal.parse_glossaries_option_from_string(input)
+			expect.not_exist(result)
+			expect.exist(err)
+			expect.truthy(err:find("Error on splitting the glossaries parameter"))
+		end)
+
+		it("handles optional fields gracefully", function()
+			local input = "makeindex:output.idx"
+			local result, err = option_spec._internal.parse_glossaries_option_from_string(input)
+			expect.not_exist(err)
+			expect.equal(result, {
+				type = "makeindex",
+				out  = "output.idx",
+				inp  = "output.ido",
+				log  = "output.idg",
+				cmd  = result.cmd, -- don't check function
+				path = "makeindex",
+			})
+		end)
+	end)
+end)

--- a/specs/typeset_hooks.lua
+++ b/specs/typeset_hooks.lua
@@ -1,0 +1,260 @@
+local lester = require 'lester'
+local lfs = require 'lfs'
+
+local describe = lester.describe
+local it       = lester.it
+local expect   = lester.expect
+local before   = lester.before
+local after    = lester.after
+
+CLUTTEALTEX_VERBOSITY = 0
+CLUTTEALTEX_TEST_ENV  = true
+
+local typeset_hooks = require 'src_lua.texrunner.typeset_hooks'
+
+describe("typeset_hooks", function()
+
+	local mock_options
+	local mock_args
+	local tmp_dir = ""
+	local original_dir = ""
+
+	before(function()
+		-- Save the current working directory
+		original_dir = assert(lfs.currentdir())
+
+		-- Create a unique temporary directory
+		tmp_dir = os.tmpname()
+		os.remove(tmp_dir) -- Remove the temp file placeholder
+		lfs.mkdir(tmp_dir)
+
+		-- Change to the temporary directory
+		lfs.chdir(tmp_dir)
+		lfs.mkdir("output")
+
+
+		mock_options = {
+			includeonly = "Chapter1,Chapter2",
+			memoize_opts = {"opt1", "opt2"},
+			quiet = 2,
+			output_directory = "./output",
+			makeindex = "makeindex",
+			glossaries = {
+				{ inp = "glo", out = "gls", cmd = function(_) return "makeglossaries" end }
+			},
+			bibtex = "bibtex",
+			biber = "biber",
+			memoize = "memoize",
+			sagetex = "sage",
+		}
+
+		mock_args = {
+			filelist = {},
+			auxstatus = {},
+			path_in_output_directory = function(ext)
+				return "./output/document." .. ext
+			end,
+			original_wd = "./",
+			bibtex_aux_hash = "oldhash",
+		}
+	end)
+
+	after(function()
+		-- Change back to the original working directory
+		lfs.chdir(original_dir)
+
+		-- Cleanup: Remove the temporary directory and its contents
+		local function rmdir(path)
+			for file in lfs.dir(path) do
+				if file ~= "." and file ~= ".." then
+					local fullpath = path .. "/" .. file
+					local attr = lfs.attributes(fullpath)
+					if attr and attr.mode == "directory" then
+						rmdir(fullpath)
+					else
+						os.remove(fullpath)
+					end
+				end
+			end
+			lfs.rmdir(path)
+		end
+		rmdir(tmp_dir)
+	end)
+
+	it("should generate includeonly injection", function()
+		local result = typeset_hooks.includeonly(mock_options, {}, "")
+		expect.equal(result, "\\includeonly{Chapter1,Chapter2}")
+	end)
+
+	it("should generate memoize injection", function()
+		local result = typeset_hooks.memoize(mock_options, {}, "")
+		expect.equal(result, "\\PassOptionsToPackage{no memo dir,extract=no}{memoize}")
+	end)
+
+	it("should generate memoize_opts injection", function()
+		local result = typeset_hooks.memoize_opts(mock_options, {}, "")
+		expect.equal(result, "\\PassOptionsToPackage{opt1,opt2}{memoize}")
+	end)
+
+	it("should handle quiet injection", function()
+		local result = typeset_hooks.quiet(mock_options, {interaction = "nonstopmode"}, "")
+		expect.truthy(result:find("\\AddToHook{begindocument/end}%[quietX%]{\\hbadness=99999 \\hfuzz=9999pt}"))
+		expect.truthy(result:find("\\AddToHook{begindocument/end}%[quiet%]{\\nonstopmode}"))
+		expect.truthy(result:find("\\AddToHook{enddocument/info}%[quiet%]{\\batchmode}"))
+	end)
+
+	it("should generate minted options injection", function()
+		local result = typeset_hooks.ps_minted(mock_options, {}, "")
+		expect.equal(result, "\\PassOptionsToPackage{outputdir=./output}{minted}")
+	end)
+
+	it("should generate epstopdf options injection", function()
+		local result = typeset_hooks.ps_epstopdf(mock_options, {}, "")
+		expect.equal(result, "\\PassOptionsToPackage{outdir=./output/}{epstopdf}")
+	end)
+
+	it("should yield correct makeindex command", function()
+		table.insert(mock_args.filelist, {path = "index.idx", abspath = "./output/index.idx"})
+		local co = coroutine.create(function()
+			typeset_hooks.makeindex(mock_options, mock_args)
+		end)
+		local status, ret
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.truthy(ret:find("makeindex"))
+
+		-- check if only yields one command
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.not_exist(ret)
+
+		-- check if terminated
+		status, ret = coroutine.resume(co)
+		expect.falsy(status)
+		expect.equal(ret, "cannot resume dead coroutine")
+	end)
+
+	it("should yield correct glossaries command", function()
+		table.insert(mock_args.filelist, {path = "glossary.glo", abspath = "./output/glossary.glo"})
+		local co = coroutine.create(function()
+			typeset_hooks.glossaries(mock_options, mock_args)
+		end)
+		local status, ret
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.equal(ret, "makeglossaries")
+
+		-- check if only yields one command
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.not_exist(ret)
+
+		-- check if terminated
+		status, ret = coroutine.resume(co)
+		expect.falsy(status)
+		expect.equal(ret, "cannot resume dead coroutine")
+	end)
+
+	it("should yield correct BibTeX command", function()
+		local file = io.open("output/document.aux", "w")
+		assert(file)
+		file:close()
+
+		local co = coroutine.create(function()
+			typeset_hooks.bibtex(mock_options, mock_args)
+		end)
+		local status, ret
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.truthy(ret:find("bibtex"))
+
+		-- check if only yields one command
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.not_exist(ret)
+
+		-- check if terminated
+		status, ret = coroutine.resume(co)
+		expect.falsy(status)
+		expect.equal(ret, "cannot resume dead coroutine")
+	end)
+
+	it("should yield correct Biber command", function()
+		table.insert(mock_args.filelist, {path = "document.bcf", abspath = "./output/document.bcf"})
+
+		local file = io.open("output/document.bcf", "w")
+		assert(file)
+		file:close()
+
+		local co = coroutine.create(function()
+			typeset_hooks.biber(mock_options, mock_args)
+		end)
+		local status, ret
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.truthy(ret:find("biber"))
+
+		-- check if only yields one command
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.not_exist(ret)
+
+		-- check if terminated
+		status, ret = coroutine.resume(co)
+		expect.falsy(status)
+		expect.equal(ret, "cannot resume dead coroutine")
+	end)
+
+	it("should yield correct Memoize extraction command", function()
+		table.insert(mock_args.filelist, {path = "document.mmz", abspath = "./output/document.mmz"})
+
+		local file = io.open("output/document.mmz", "w")
+		assert(file)
+		file:write("\\mmzNewExtern")
+		file:close()
+
+		local co = coroutine.create(function()
+			typeset_hooks.memoize_run(mock_options, mock_args)
+		end)
+		local status, ret
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.truthy(ret:find("memoize"))
+
+		-- check if only yields one command
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.not_exist(ret)
+
+		-- check if terminated
+		status, ret = coroutine.resume(co)
+		expect.falsy(status)
+		expect.equal(ret, "cannot resume dead coroutine")
+	end)
+
+	it("should yield correct Sagetex command", function()
+		table.insert(mock_args.filelist, {path = "document.sage", abspath = "./output/document.sage"})
+
+		local file = io.open("output/document.sage", "w")
+		assert(file)
+		file:close()
+
+		local co = coroutine.create(function()
+			typeset_hooks.sagetex(mock_options, mock_args)
+		end)
+		local status, ret
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.truthy(ret:find("sage"))
+
+		-- check if only yields one command
+		status, ret = coroutine.resume(co)
+		expect.truthy(status)
+		expect.not_exist(ret)
+
+		-- check if terminated
+		status, ret = coroutine.resume(co)
+		expect.falsy(status)
+		expect.equal(ret, "cannot resume dead coroutine")
+	end)
+end)

--- a/src_teal/cluttealtex.tl
+++ b/src_teal/cluttealtex.tl
@@ -30,7 +30,7 @@ local os = require"os_"
 local filesys = require "lfs"
 
 -- custom modules
-local reruncheck                   = require "texrunner.reruncheck"
+local common_t                     = require "texrunner.common_types"
 local handle_cluttealtex_options   = require "texrunner.handleoption".handle_cluttealtex_options
 local watcher                      = require"texrunner.watcher"
 local get_typesetter               = require"texrunner.typeset".get_typesetter
@@ -83,7 +83,7 @@ local do_typeset = get_typesetter{
 }
 
 -- Variables to track success status and file lists produced during typesetting.
-local success, filelist: boolean, {reruncheck.Filemap_ele}
+local success, filelist: boolean, {common_t.Filemap_ele}
 local _: any -- Placeholder for unused return values.
 
 if options.watch then

--- a/src_teal/texrunner/checkdriver.tl
+++ b/src_teal/texrunner/checkdriver.tl
@@ -21,7 +21,7 @@ local assert = assert
 local ipairs = ipairs
 local pathutil = require "texrunner.pathutil"
 local message = require "texrunner.message"
-local reruncheck = require"texrunner.reruncheck"
+local common_t = require"texrunner.common_types"
 
 -- Record definition for expected driver values
 local record Values
@@ -237,7 +237,7 @@ local mismatch_output:{string:function} = {
 
 -- Main function to check drivers based on expected driver and loaded files
 -- @param expected_driver: one of "dvips", "dvipdfmx", "dvisvgm", "pdftex", "xetex", "luatex"
-local function checkdriver(expected_driver: string, filelist: {reruncheck.Filemap_ele}): {string}
+local function checkdriver(expected_driver: string, filelist: {common_t.Filemap_ele}): {string}
 	if CLUTTEALTEX_VERBOSITY >= 1 then
 		message.info("checkdriver: expects ", expected_driver)
 	end

--- a/src_teal/texrunner/common_types.tl
+++ b/src_teal/texrunner/common_types.tl
@@ -10,6 +10,11 @@ local record Module
 		"output"
 		"input"
 	end
+	record Status
+		mtime: number
+		size: number
+		md5sum: string
+	end
 end
 
 return Module

--- a/src_teal/texrunner/common_types.tl
+++ b/src_teal/texrunner/common_types.tl
@@ -15,6 +15,8 @@ local record Module
 		size: number
 		md5sum: string
 	end
+	type filelist = {Filemap_ele}
+	type auxstatus = {string: Status}
 end
 
 return Module

--- a/src_teal/texrunner/common_types.tl
+++ b/src_teal/texrunner/common_types.tl
@@ -1,0 +1,15 @@
+local record Module
+	record Filemap_ele
+		path: string
+		abspath: string
+		kind: FileKind
+	end
+	-- Enum representing types of files handled by the module
+	enum FileKind
+		"auxiliary"
+		"output"
+		"input"
+	end
+end
+
+return Module

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -350,16 +350,19 @@ end
 local function handle_cluttealtex_options(arg: {string}): string, TexEngine.Engine, options.Options
 	-- Define default options
 	local default_options:options.Options = {
-			tex_extraoptions = {},
+			-- important default values because these options need to be tables
+			-- (otherwise iterating over them fails)
+			tex_extraoptions      = {},
 			dvipdfmx_extraoptions = {},
-			package_support = {},
+			package_support       = {},
+			hooks                 = options.init_hooks(),
 			-- ordinary default values
-			max_iterations = 3,
-			skip_first = false,
-			interaction = "nonstopmode",
-			file_line_error = true,
-			halt_on_error = true,
-			output_format = "pdf",
+			max_iterations        = 3,
+			skip_first            = false,
+			interaction           = "nonstopmode",
+			file_line_error       = true,
+			halt_on_error         = true,
+			output_format         = "pdf",
 	}
 
 	-- Parse configuration and command-line options

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -26,6 +26,7 @@ local TexEngine   = require "texrunner.tex_engine"
 local message     = require "texrunner.message"
 local fsutil      = require "texrunner.fsutil"
 local option_spec = require "texrunner.option_spec".spec
+local init_hooks  = require "texrunner.option_spec".init_hooks
 local usage = require "texrunner.option_spec".usage
 local read_cfg = require "texrunner.read_cfg".read_cfg
 
@@ -81,17 +82,45 @@ local function query_options(name:string, kind:string): Option,string,boolean
 	return option_spec[key], key, no
 end
 
+local function merge_hook_type(ht:string, hs:{number:any}, ret:{string:any})
+	local hooks = ret["hooks"] as {string:{number:any}}
+	if ht:find("^suggestion") then
+		-- hooks are enabled by default
+		-- disable hooks not set in the next options
+		for k,_ in pairs(hooks[ht]) do
+			if not hs[k] then
+				hooks[ht][k] = nil
+			end
+		end
+	else
+		-- hooks are disabled by default
+		-- enable hooks set in the next options
+		for k,v in pairs(hs) do
+			hooks[ht][k] = v
+		end
+	end
+end
+
 -- Function to merge multiple option tables into one
 -- first table has highest priority etc.
 local function merge_options(...: options.Options): options.Options
 	-- Table to hold merged options
 	local ret:{string:any} = {}
+	local first = true
 	-- Iterate over each passed options table
 	for _, i in ipairs{...} do
 		for k,v in pairs(i as {string:any}) do
-			-- Add each option from the table to the result
-			ret[k] = v
+			if k == "hooks" and not first then
+				-- hooks need t be handled specially
+				for ht, hs in pairs(v as {string:{number:any}}) do
+					merge_hook_type(ht, hs, ret)
+				end
+			else
+				-- Add each option from the table to the result
+				ret[k] = v
+			end
 		end
+		first = false
 	end
 	-- Return the merged options table
 	return ret as options.Options
@@ -355,7 +384,6 @@ local function handle_cluttealtex_options(arg: {string}): string, TexEngine.Engi
 			tex_extraoptions      = {},
 			dvipdfmx_extraoptions = {},
 			package_support       = {},
-			hooks                 = options.init_hooks(),
 			-- ordinary default values
 			max_iterations        = 3,
 			skip_first            = false,
@@ -364,6 +392,7 @@ local function handle_cluttealtex_options(arg: {string}): string, TexEngine.Engi
 			halt_on_error         = true,
 			output_format         = "pdf",
 	}
+	init_hooks(default_options)
 
 	-- Parse configuration and command-line options
 	local config_options, inputfile = parse_config_file()

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -392,7 +392,7 @@ local function handle_cluttealtex_options(arg: {string}): string, TexEngine.Engi
 			halt_on_error         = true,
 			output_format         = "pdf",
 	}
-	init_hooks(default_options)
+	init_hooks(default_options, option_spec)
 
 	-- Parse configuration and command-line options
 	local config_options, inputfile = parse_config_file()

--- a/src_teal/texrunner/handleoption.tl
+++ b/src_teal/texrunner/handleoption.tl
@@ -462,6 +462,7 @@ local record Module
 		parse_command_line_options: function(arg: {string}): options.Options, integer
 		parse_config_file:          function(): options.Options, string
 		query_options:              function(name:string, kind:string): Option,string,boolean
+		merge_hook_type:            function(ht:string, hs:{number:any}, ret:{string:any})
 	end
 end
 
@@ -481,6 +482,7 @@ if CLUTTEALTEX_TEST_ENV then
 		parse_command_line_options = parse_command_line_options,
 		parse_config_file          = parse_config_file,
 		query_options              = query_options,
+		merge_hook_type            = merge_hook_type,
 	}
 end
 return _M

--- a/src_teal/texrunner/option.tl
+++ b/src_teal/texrunner/option.tl
@@ -26,6 +26,8 @@ else
 	exit = os.exit
 end
 
+local option_t = require"texrunner.option_type"
+
 local record Module
 	parseoption: function(arg:{string}, query_long_options:(function(string):Option,string,boolean), query_short_options:(function(string):Option,string,boolean)): {{string,string|boolean}},integer
 	_internal: internal
@@ -44,6 +46,11 @@ local record Module
 		handle_cfg:          function({string:any}, table)
 		no_cli:              boolean
 		no_cfg:              boolean
+		suggestion_handlers: SuggestionHandlers
+	end
+	record SuggestionHandlers
+		file_based:    function(option_t.Options)
+		execlog_based: function(option_t.Options)
 	end
 end
 

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -22,6 +22,7 @@ local option_t      = require"texrunner.option_type"
 local pathutil      = require "texrunner.pathutil"
 local message       = require "texrunner.message"
 local typeset_hooks = require "texrunner.typeset_hooks"
+local common_t      = require "texrunner.common_types"
 
 global CLUTTEALTEX_VERSION:string
 

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -16,11 +16,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
-local Option    = require "texrunner.option".Option
-local shellutil = require "texrunner.shellutil"
-local option_t  = require"texrunner.option_type"
-local pathutil  = require "texrunner.pathutil"
-local message   = require "texrunner.message"
+local Option        = require "texrunner.option".Option
+local shellutil     = require "texrunner.shellutil"
+local option_t      = require"texrunner.option_type"
+local pathutil      = require "texrunner.pathutil"
+local message       = require "texrunner.message"
+local typeset_hooks = require "texrunner.typeset_hooks"
 
 global CLUTTEALTEX_VERSION:string
 
@@ -433,6 +434,8 @@ local option_spec:{string:Option} = {
 			assert(options.includeonly == nil, "multiple --includeonly options")
 			if param is string then
 				options.includeonly = param
+				options.hooks = options.hooks or option_t.init_hooks()
+				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.includeonly)] = {typeset_hooks.includeonly, "includeonly"}
 			else
 				error("invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -29,9 +29,30 @@ global CLUTTEALTEX_VERSION:string
 local record Module
 	spec:{string:Option}
 	usage:function({string})
-	init_hooks: function(option_t.Options)
+	init_hooks: function(option_t.Options, {string:Option})
 end
 local _M:Module = {}
+
+local function init_hooks(o:option_t.Options, spec:{string:Option})
+	o.hooks = o.hooks or {}
+
+	o.hooks.tex_injection            = {}
+	-- o.hooks.pre_compile              = {}
+	o.hooks.post_compile             = {}
+	-- o.hooks.pre_build                = {}
+	-- o.hooks.post_build               = {}
+	o.hooks.suggestion_file_based    = {}
+	o.hooks.suggestion_execlog_based = {}
+
+	for _,v in pairs(spec) do
+		if v.suggestion_handlers and v.suggestion_handlers.file_based then
+			v.suggestion_handlers.file_based(o)
+		end
+		if v.suggestion_handlers and v.suggestion_handlers.execlog_based then
+			v.suggestion_handlers.execlog_based(o)
+		end
+	end
+end
 
 local function split(opt:string): {string}
 	local ret,builder,state = {},{},0
@@ -125,7 +146,7 @@ local function parse_glossaries_option_from_string(opt:string): option_t.Glos, s
 	return parse_glossaries_option_from_table{type=s[1], out=s[2], inp=s[3], log=s[4], path=s[5], cmd_args=s[6]}
 end
 
-function _M.usage(arg:{string})
+local function usage(arg:{string})
 	io.write(string.format([[
 ClutteakTeX: Process TeX files without cluttering your working directory
 
@@ -233,7 +254,7 @@ Options:
 end
 
 
-_M.spec = {
+local spec = {
 	-- Options for CluttealTeX
 	engine = {
 		short = "e",
@@ -402,7 +423,7 @@ _M.spec = {
 		long = "help",
 		allow_single_hyphen = true,
 		handle_cli = function(options:option_t.Options, param:string|boolean)
-			_M.usage(arg)
+			usage(arg)
 			os.exit(0)
 		end,
 	},
@@ -442,7 +463,7 @@ _M.spec = {
 			assert(options.includeonly == nil, "multiple --includeonly options")
 			if param is string then
 				options.includeonly = param
-				if not options.hooks then _M.init_hooks(options) end
+				if not options.hooks then init_hooks(options, _M.spec) end
 				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.includeonly)] = {typeset_hooks.includeonly, "includeonly"}
 			else
 				error("invalid param type")
@@ -496,13 +517,13 @@ _M.spec = {
 			local known_packages:{string:function(option_t.Options)} = {
 				-- minted uses offset 0.1 in hooks
 				minted = function(o: option_t.Options)
-					if not o.hooks then _M.init_hooks(o) end
+					if not o.hooks then init_hooks(o, _M.spec) end
 					o.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.package_support)+0.1] = {typeset_hooks.ps_minted, "package_support minted"}
 					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.1] = nil
 				end,
 				-- epstopdf uses offset 0.2 in hooks
 				epstopdf = function(o: option_t.Options)
-					if not o.hooks then _M.init_hooks(o) end
+					if not o.hooks then init_hooks(o, _M.spec) end
 					o.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.package_support)+0.2] = {typeset_hooks.ps_epstopdf, "package_support epstopdf"}
 					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.2] = nil
 				end,
@@ -530,7 +551,7 @@ _M.spec = {
 			assert(param == "dvipdfmx" or param == "dvips" or param == "dvisvgm", "wrong value for --check-driver option")
 			if param is string then
 				options.check_driver = param
-				if not options.hooks then _M.init_hooks(options) end
+				if not options.hooks then init_hooks(options, _M.spec) end
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.check_driver)] = {typeset_hooks.check_driver, "check_driver"}
 			else
 				assert(param is string, "invalid param type")
@@ -556,7 +577,7 @@ _M.spec = {
 			assert(options.makeindex == nil, "multiple --makeindex options")
 			if param is string then
 				options.makeindex = param
-				if not options.hooks then _M.init_hooks(options) end
+				if not options.hooks then init_hooks(options, _M.spec) end
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.makeindex)] = {typeset_hooks.makeindex, "makeindex"}
 				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.makeindex)] = nil
 			else
@@ -583,7 +604,7 @@ _M.spec = {
 			assert(options.biber == nil, "multiple --bibtex/--biber options")
 			if param is string then
 				options.bibtex = param
-				if not options.hooks then _M.init_hooks(options) end
+				if not options.hooks then init_hooks(options, _M.spec) end
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.bibtex)] = {typeset_hooks.bibtex, "bibtex"}
 				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.bibtex)] = nil
 			else
@@ -610,7 +631,7 @@ _M.spec = {
 			assert(options.bibtex == nil, "multiple --bibtex/--biber options")
 			if param is string then
 				options.biber = param
-				if not options.hooks then _M.init_hooks(options) end
+				if not options.hooks then init_hooks(options, _M.spec) end
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.biber)] = {typeset_hooks.biber, "biber"}
 				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.biber)] = nil
 			else
@@ -636,7 +657,7 @@ _M.spec = {
 			assert(options.sagetex == nil, "multiple --sagetex options")
 			if param is string then
 				options.sagetex = param
-				if not options.hooks then _M.init_hooks(options) end
+				if not options.hooks then init_hooks(options, _M.spec) end
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.sagetex)] = {typeset_hooks.sagetex, "sagetex"}
 				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.sagetex)] = nil
 			else
@@ -657,7 +678,7 @@ _M.spec = {
 			if param is string then
 				options.glossaries = options.glossaries or {}
 				table.insert(options.glossaries, assert(parse_glossaries_option_from_string(param)))
-				if not options.hooks then _M.init_hooks(options) end
+				if not options.hooks then init_hooks(options, _M.spec) end
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.glossaries)] = {typeset_hooks.glossaries, "glossaries"}
 			else
 				error("invalid param type")
@@ -699,7 +720,7 @@ _M.spec = {
 
 			options.glossaries = options.glossaries or {}
 			table.insert(options.glossaries, assert(parse_glossaries_option_from_table(param)))
-			if not options.hooks then _M.init_hooks(options) end
+			if not options.hooks then init_hooks(options, _M.spec) end
 			options.hooks.post_compile[assert(option_t.hook_prios.post_compile.glossaries)] = {typeset_hooks.glossaries, "glossaries"}
 		end,
 	},
@@ -727,7 +748,7 @@ _M.spec = {
 				else
 					options.memoize = param
 				end
-				if not options.hooks then _M.init_hooks(options) end
+				if not options.hooks then init_hooks(options, _M.spec) end
 				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.memoize+0.1)] = {typeset_hooks.memoize, "memoize"}
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.memoize)] = {typeset_hooks.memoize_run, "memoize"}
 				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.memoize)] = nil
@@ -743,7 +764,7 @@ _M.spec = {
 			if param is string then
 				options.memoize_opts = options.memoize_opts or {}
 				table.insert(options.memoize_opts, param)
-				if not options.hooks then _M.init_hooks(options) end
+				if not options.hooks then init_hooks(options, _M.spec) end
 				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.memoize-0.2)] = {typeset_hooks.memoize_opts, "memoize_opts"}
 			else
 				error("invalid param type")
@@ -758,7 +779,7 @@ _M.spec = {
 			assert(options.quiet == nil, "multiple --quiet options")
 			if param is string then
 				options.quiet = assert(tonumber(param) as integer, "parameter must be an integer")
-				if not options.hooks then _M.init_hooks(options) end
+				if not options.hooks then init_hooks(options, _M.spec) end
 				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.quiet)] = {typeset_hooks.quiet, "quiet"}
 			else
 				error("invalid param type")
@@ -941,25 +962,8 @@ _M.spec = {
 	},
 }
 
-function _M.init_hooks(o:option_t.Options)
-	o.hooks = o.hooks or {}
-
-	o.hooks.tex_injection            = {}
-	-- o.hooks.pre_compile              = {}
-	o.hooks.post_compile             = {}
-	-- o.hooks.pre_build                = {}
-	-- o.hooks.post_build               = {}
-	o.hooks.suggestion_file_based    = {}
-	o.hooks.suggestion_execlog_based = {}
-
-	for _,v in pairs(_M.spec) do
-		if v.suggestion_handlers and v.suggestion_handlers.file_based then
-			v.suggestion_handlers.file_based(o)
-		end
-		if v.suggestion_handlers and v.suggestion_handlers.execlog_based then
-			v.suggestion_handlers.execlog_based(o)
-		end
-	end
-end
+_M.init_hooks = init_hooks
+_M.spec = spec
+_M.usage = usage
 
 return _M

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -535,6 +535,12 @@ local option_spec:{string:Option} = {
 				options.makeindex = param
 				options.hooks = options.hooks or option_t.init_hooks()
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.makeindex)] = {typeset_hooks.makeindex, "makeindex"}
+				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.makeindex)] = {
+					function(execlog:string, _:option_t.Options): boolean
+						return string.find(execlog, "No file [^\n]+%.ind%.") ~= nil
+					end,
+					"You may want to use --makeindex option."
+				}
 			else
 				error("invalid param type")
 			end
@@ -551,6 +557,12 @@ local option_spec:{string:Option} = {
 				options.bibtex = param
 				options.hooks = options.hooks or option_t.init_hooks()
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.bibtex)] = {typeset_hooks.bibtex, "bibtex"}
+				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.bibtex)] = {
+					function(execlog:string, o:option_t.Options): boolean
+						return string.find(execlog, "No file [^\n]+%.bbl%.") ~= nil and not o.biber
+					end,
+					"You may want to use --bibtex or --biber option."
+				}
 			else
 				error("invalid param type")
 			end
@@ -567,6 +579,12 @@ local option_spec:{string:Option} = {
 				options.biber = param
 				options.hooks = options.hooks or option_t.init_hooks()
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.biber)] = {typeset_hooks.biber, "biber"}
+				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.biber)] = {
+					function(execlog:string, o:option_t.Options): boolean
+						return string.find(execlog, "No file [^\n]+%.bbl%.") ~= nil and not o.bibtex
+					end,
+					"You may want to use --bibtex or --biber option."
+				}
 			else
 				error("invalid param type")
 			end
@@ -582,6 +600,12 @@ local option_spec:{string:Option} = {
 				options.sagetex = param
 				options.hooks = options.hooks or option_t.init_hooks()
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.sagetex)] = {typeset_hooks.sagetex, "sagetex"}
+				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.sagetex)] = {
+					function(execlog:string, _:option_t.Options): boolean
+						return string.find(execlog, "Run Sage on") ~= nil
+					end,
+					"You may want to use --sagetex option."
+				}
 			else
 				error("invalid param type")
 			end
@@ -663,6 +687,12 @@ local option_spec:{string:Option} = {
 				options.hooks = options.hooks or option_t.init_hooks()
 				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.memoize+0.1)] = {typeset_hooks.memoize, "memoize"}
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.memoize)] = {typeset_hooks.memoize_run, "memoize"}
+				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.memoize)] = {
+					function(execlog:string, _:option_t.Options): boolean
+						return string.find(execlog, "Package memoize Warning") ~= nil
+					end,
+					"You may want to use --memoize option."
+				}
 			else
 				error("invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -470,11 +470,37 @@ local option_spec:{string:Option} = {
 		param = true,
 		accumulate = true,
 		handle_cli = function(options:option_t.Options, param:string|boolean)
-			local known_packages:{string:boolean} = {["minted"] = true, ["epstopdf"] = true}
+			local known_packages:{string:function(option_t.Options)} = {
+				-- minted uses offset 0.1 in hooks
+				minted = function(o: option_t.Options)
+					o.hooks = o.hooks or option_t.init_hooks()
+					o.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.package_support)+0.1] = {typeset_hooks.ps_minted, "package_support minted"}
+					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.1] = {
+						function(fileinfo:common_t.Filemap_ele): boolean
+								return string.match(fileinfo.path, "minted/minted%.sty$") ~= nil
+						end,
+						"You may want to use --package-support=minted option."
+					}
+				end,
+				-- epstopdf uses offset 0.2 in hooks
+				epstopdf = function(o: option_t.Options)
+					o.hooks = o.hooks or option_t.init_hooks()
+					o.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.package_support)+0.2] = {typeset_hooks.ps_epstopdf, "package_support epstopdf"}
+					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.2] = {
+						function(fileinfo:common_t.Filemap_ele): boolean
+								return string.match(fileinfo.path, "epstopdf%.sty$") ~= nil
+						end,
+						"You may want to use --package-support=epstopdf option."
+					}
+				end,
+			}
 			if param is string then
 				for pkg in string.gmatch(param, "[^,%s]+") do
 					options.package_support[pkg] = true
-					if not known_packages[pkg] and CLUTTEALTEX_VERBOSITY >= 1 then
+					if known_packages[pkg] then
+						-- register the corresponding hook
+						known_packages[pkg](options)
+					elseif CLUTTEALTEX_VERBOSITY >= 1 then
 						message.warn("CluttealTeX provides no special support for '"..pkg.."'.")
 					end
 				end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -26,6 +26,13 @@ local common_t      = require "texrunner.common_types"
 
 global CLUTTEALTEX_VERSION:string
 
+local record Module
+	spec:{string:Option}
+	usage:function({string})
+	init_hooks: function(option_t.Options)
+end
+local _M:Module = {}
+
 local function split(opt:string): {string}
 	local ret,builder,state = {},{},0
 	for c in opt:gmatch(".") do
@@ -118,7 +125,7 @@ local function parse_glossaries_option_from_string(opt:string): option_t.Glos, s
 	return parse_glossaries_option_from_table{type=s[1], out=s[2], inp=s[3], log=s[4], path=s[5], cmd_args=s[6]}
 end
 
-local function usage(arg:{string})
+function _M.usage(arg:{string})
 	io.write(string.format([[
 ClutteakTeX: Process TeX files without cluttering your working directory
 
@@ -226,7 +233,7 @@ Options:
 end
 
 
-local option_spec:{string:Option} = {
+_M.spec = {
 	-- Options for CluttealTeX
 	engine = {
 		short = "e",
@@ -395,7 +402,7 @@ local option_spec:{string:Option} = {
 		long = "help",
 		allow_single_hyphen = true,
 		handle_cli = function(options:option_t.Options, param:string|boolean)
-			usage(arg)
+			_M.usage(arg)
 			os.exit(0)
 		end,
 	},
@@ -435,7 +442,7 @@ local option_spec:{string:Option} = {
 			assert(options.includeonly == nil, "multiple --includeonly options")
 			if param is string then
 				options.includeonly = param
-				options.hooks = options.hooks or option_t.init_hooks()
+				if not options.hooks then _M.init_hooks(options) end
 				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.includeonly)] = {typeset_hooks.includeonly, "includeonly"}
 			else
 				error("invalid param type")
@@ -469,30 +476,34 @@ local option_spec:{string:Option} = {
 		long = "package-support",
 		param = true,
 		accumulate = true,
+		suggestion_handlers = {
+			file_based = function(o:option_t.Options)
+				o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.1] = {
+					function(fileinfo:common_t.Filemap_ele): boolean
+							return string.find(fileinfo.path, "minted/minted%.sty$") ~= nil
+					end,
+					"You may want to use --package-support=minted option."
+				}
+				o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.2] = {
+					function(fileinfo:common_t.Filemap_ele): boolean
+							return string.find(fileinfo.path, "epstopdf%.sty$") ~= nil
+					end,
+					"You may want to use --package-support=epstopdf option."
+				}
+			end
+		},
 		handle_cli = function(options:option_t.Options, param:string|boolean)
 			local known_packages:{string:function(option_t.Options)} = {
 				-- minted uses offset 0.1 in hooks
 				minted = function(o: option_t.Options)
-					o.hooks = o.hooks or option_t.init_hooks()
+					if not o.hooks then _M.init_hooks(o) end
 					o.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.package_support)+0.1] = {typeset_hooks.ps_minted, "package_support minted"}
-					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.1] = {
-						function(fileinfo:common_t.Filemap_ele): boolean
-								return string.find(fileinfo.path, "minted/minted%.sty$") ~= nil
-						end,
-						"You may want to use --package-support=minted option."
-					}
 					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.1] = nil
 				end,
 				-- epstopdf uses offset 0.2 in hooks
 				epstopdf = function(o: option_t.Options)
-					o.hooks = o.hooks or option_t.init_hooks()
+					if not o.hooks then _M.init_hooks(o) end
 					o.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.package_support)+0.2] = {typeset_hooks.ps_epstopdf, "package_support epstopdf"}
-					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.2] = {
-						function(fileinfo:common_t.Filemap_ele): boolean
-								return string.find(fileinfo.path, "epstopdf%.sty$") ~= nil
-						end,
-						"You may want to use --package-support=epstopdf option."
-					}
 					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.2] = nil
 				end,
 			}
@@ -519,7 +530,7 @@ local option_spec:{string:Option} = {
 			assert(param == "dvipdfmx" or param == "dvips" or param == "dvisvgm", "wrong value for --check-driver option")
 			if param is string then
 				options.check_driver = param
-				options.hooks = options.hooks or option_t.init_hooks()
+				if not options.hooks then _M.init_hooks(options) end
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.check_driver)] = {typeset_hooks.check_driver, "check_driver"}
 			else
 				assert(param is string, "invalid param type")
@@ -530,19 +541,23 @@ local option_spec:{string:Option} = {
 		long = "makeindex",
 		param = true,
 		default = "makeindex",
-		handle_cli = function(options:option_t.Options, param:string|boolean)
-			assert(not options.glossaries, "'makeindex' cannot be used together with 'glossaries'\nUse e.g. --glossaries='makeindex:main.ind:main.idx:main.ilg' instead of makeindex")
-			assert(options.makeindex == nil, "multiple --makeindex options")
-			if param is string then
-				options.makeindex = param
-				options.hooks = options.hooks or option_t.init_hooks()
-				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.makeindex)] = {typeset_hooks.makeindex, "makeindex"}
-				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.makeindex)] = {
+		suggestion_handlers = {
+			execlog_based = function(o:option_t.Options)
+				o.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.makeindex)] = {
 					function(execlog:string, _:option_t.Options): boolean
 						return string.find(execlog, "No file [^\n]+%.ind%.") ~= nil
 					end,
 					"You may want to use --makeindex option."
 				}
+			end
+		},
+		handle_cli = function(options:option_t.Options, param:string|boolean)
+			assert(not options.glossaries, "'makeindex' cannot be used together with 'glossaries'\nUse e.g. --glossaries='makeindex:main.ind:main.idx:main.ilg' instead of makeindex")
+			assert(options.makeindex == nil, "multiple --makeindex options")
+			if param is string then
+				options.makeindex = param
+				if not options.hooks then _M.init_hooks(options) end
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.makeindex)] = {typeset_hooks.makeindex, "makeindex"}
 				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.makeindex)] = nil
 			else
 				error("invalid param type")
@@ -553,19 +568,23 @@ local option_spec:{string:Option} = {
 		long = "bibtex",
 		param = true,
 		default = "bibtex",
-		handle_cli = function(options:option_t.Options, param:string|boolean)
-			assert(options.bibtex == nil, "multiple --bibtex options")
-			assert(options.biber == nil, "multiple --bibtex/--biber options")
-			if param is string then
-				options.bibtex = param
-				options.hooks = options.hooks or option_t.init_hooks()
-				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.bibtex)] = {typeset_hooks.bibtex, "bibtex"}
-				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.bibtex)] = {
+		suggestion_handlers = {
+			execlog_based = function(o:option_t.Options)
+				o.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.bibtex)] = {
 					function(execlog:string, o:option_t.Options): boolean
 						return string.find(execlog, "No file [^\n]+%.bbl%.") ~= nil and not o.biber
 					end,
 					"You may want to use --bibtex or --biber option."
 				}
+			end
+		},
+		handle_cli = function(options:option_t.Options, param:string|boolean)
+			assert(options.bibtex == nil, "multiple --bibtex options")
+			assert(options.biber == nil, "multiple --bibtex/--biber options")
+			if param is string then
+				options.bibtex = param
+				if not options.hooks then _M.init_hooks(options) end
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.bibtex)] = {typeset_hooks.bibtex, "bibtex"}
 				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.bibtex)] = nil
 			else
 				error("invalid param type")
@@ -576,19 +595,23 @@ local option_spec:{string:Option} = {
 		long = "biber",
 		param = true,
 		default = "biber",
-		handle_cli = function(options:option_t.Options, param:string|boolean)
-			assert(options.biber == nil, "multiple --biber options")
-			assert(options.bibtex == nil, "multiple --bibtex/--biber options")
-			if param is string then
-				options.biber = param
-				options.hooks = options.hooks or option_t.init_hooks()
-				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.biber)] = {typeset_hooks.biber, "biber"}
-				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.biber)] = {
+		suggestion_handlers = {
+			execlog_based = function(o:option_t.Options)
+				o.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.biber)] = {
 					function(execlog:string, o:option_t.Options): boolean
 						return string.find(execlog, "No file [^\n]+%.bbl%.") ~= nil and not o.bibtex
 					end,
 					"You may want to use --bibtex or --biber option."
 				}
+			end
+		},
+		handle_cli = function(options:option_t.Options, param:string|boolean)
+			assert(options.biber == nil, "multiple --biber options")
+			assert(options.bibtex == nil, "multiple --bibtex/--biber options")
+			if param is string then
+				options.biber = param
+				if not options.hooks then _M.init_hooks(options) end
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.biber)] = {typeset_hooks.biber, "biber"}
 				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.biber)] = nil
 			else
 				error("invalid param type")
@@ -599,18 +622,22 @@ local option_spec:{string:Option} = {
 		long = "sagetex",
 		param = true,
 		default = "sage",
-		handle_cli = function(options:option_t.Options, param:string|boolean)
-			assert(options.sagetex == nil, "multiple --sagetex options")
-			if param is string then
-				options.sagetex = param
-				options.hooks = options.hooks or option_t.init_hooks()
-				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.sagetex)] = {typeset_hooks.sagetex, "sagetex"}
-				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.sagetex)] = {
+		suggestion_handlers = {
+			execlog_based = function(o:option_t.Options)
+				o.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.sagetex)] = {
 					function(execlog:string, _:option_t.Options): boolean
 						return string.find(execlog, "Run Sage on") ~= nil
 					end,
 					"You may want to use --sagetex option."
 				}
+			end
+		},
+		handle_cli = function(options:option_t.Options, param:string|boolean)
+			assert(options.sagetex == nil, "multiple --sagetex options")
+			if param is string then
+				options.sagetex = param
+				if not options.hooks then _M.init_hooks(options) end
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.sagetex)] = {typeset_hooks.sagetex, "sagetex"}
 				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.sagetex)] = nil
 			else
 				error("invalid param type")
@@ -630,7 +657,7 @@ local option_spec:{string:Option} = {
 			if param is string then
 				options.glossaries = options.glossaries or {}
 				table.insert(options.glossaries, assert(parse_glossaries_option_from_string(param)))
-				options.hooks = options.hooks or option_t.init_hooks()
+				if not options.hooks then _M.init_hooks(options) end
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.glossaries)] = {typeset_hooks.glossaries, "glossaries"}
 			else
 				error("invalid param type")
@@ -672,7 +699,7 @@ local option_spec:{string:Option} = {
 
 			options.glossaries = options.glossaries or {}
 			table.insert(options.glossaries, assert(parse_glossaries_option_from_table(param)))
-			options.hooks = options.hooks or option_t.init_hooks()
+			if not options.hooks then _M.init_hooks(options) end
 			options.hooks.post_compile[assert(option_t.hook_prios.post_compile.glossaries)] = {typeset_hooks.glossaries, "glossaries"}
 		end,
 	},
@@ -680,6 +707,16 @@ local option_spec:{string:Option} = {
 		long = "memoize",
 		param = true,
 		default = "perl",
+		suggestion_handlers = {
+			execlog_based = function(o:option_t.Options)
+				o.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.memoize)] = {
+					function(execlog:string, _:option_t.Options): boolean
+						return string.find(execlog, "Package memoize Warning") ~= nil
+					end,
+					"You may want to use --memoize option."
+				}
+			end
+		},
 		handle_cli = function(options:option_t.Options, param:string|boolean)
 			assert(options.memoize == nil, "multiple --memoize options")
 			if param is string then
@@ -690,15 +727,9 @@ local option_spec:{string:Option} = {
 				else
 					options.memoize = param
 				end
-				options.hooks = options.hooks or option_t.init_hooks()
+				if not options.hooks then _M.init_hooks(options) end
 				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.memoize+0.1)] = {typeset_hooks.memoize, "memoize"}
 				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.memoize)] = {typeset_hooks.memoize_run, "memoize"}
-				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.memoize)] = {
-					function(execlog:string, _:option_t.Options): boolean
-						return string.find(execlog, "Package memoize Warning") ~= nil
-					end,
-					"You may want to use --memoize option."
-				}
 				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.memoize)] = nil
 			else
 				error("invalid param type")
@@ -712,7 +743,7 @@ local option_spec:{string:Option} = {
 			if param is string then
 				options.memoize_opts = options.memoize_opts or {}
 				table.insert(options.memoize_opts, param)
-				options.hooks = options.hooks or option_t.init_hooks()
+				if not options.hooks then _M.init_hooks(options) end
 				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.memoize-0.2)] = {typeset_hooks.memoize_opts, "memoize_opts"}
 			else
 				error("invalid param type")
@@ -727,7 +758,7 @@ local option_spec:{string:Option} = {
 			assert(options.quiet == nil, "multiple --quiet options")
 			if param is string then
 				options.quiet = assert(tonumber(param) as integer, "parameter must be an integer")
-				options.hooks = options.hooks or option_t.init_hooks()
+				if not options.hooks then _M.init_hooks(options) end
 				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.quiet)] = {typeset_hooks.quiet, "quiet"}
 			else
 				error("invalid param type")
@@ -910,7 +941,25 @@ local option_spec:{string:Option} = {
 	},
 }
 
-return {
-	spec = option_spec,
-	usage = usage,
-}
+function _M.init_hooks(o:option_t.Options)
+	o.hooks = o.hooks or {}
+
+	o.hooks.tex_injection            = {}
+	-- o.hooks.pre_compile              = {}
+	o.hooks.post_compile             = {}
+	-- o.hooks.pre_build                = {}
+	-- o.hooks.post_build               = {}
+	o.hooks.suggestion_file_based    = {}
+	o.hooks.suggestion_execlog_based = {}
+
+	for _,v in pairs(_M.spec) do
+		if v.suggestion_handlers and v.suggestion_handlers.file_based then
+			v.suggestion_handlers.file_based(o)
+		end
+		if v.suggestion_handlers and v.suggestion_handlers.execlog_based then
+			v.suggestion_handlers.execlog_based(o)
+		end
+	end
+end
+
+return _M

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -580,6 +580,8 @@ local option_spec:{string:Option} = {
 			assert(options.sagetex == nil, "multiple --sagetex options")
 			if param is string then
 				options.sagetex = param
+				options.hooks = options.hooks or option_t.init_hooks()
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.sagetex)] = {typeset_hooks.sagetex, "sagetex"}
 			else
 				error("invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -662,6 +662,7 @@ local option_spec:{string:Option} = {
 				end
 				options.hooks = options.hooks or option_t.init_hooks()
 				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.memoize+0.1)] = {typeset_hooks.memoize, "memoize"}
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.memoize)] = {typeset_hooks.memoize_run, "memoize"}
 			else
 				error("invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -481,6 +481,7 @@ local option_spec:{string:Option} = {
 						end,
 						"You may want to use --package-support=minted option."
 					}
+					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.1] = nil
 				end,
 				-- epstopdf uses offset 0.2 in hooks
 				epstopdf = function(o: option_t.Options)
@@ -492,6 +493,7 @@ local option_spec:{string:Option} = {
 						end,
 						"You may want to use --package-support=epstopdf option."
 					}
+					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.2] = nil
 				end,
 			}
 			if param is string then
@@ -541,6 +543,7 @@ local option_spec:{string:Option} = {
 					end,
 					"You may want to use --makeindex option."
 				}
+				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.makeindex)] = nil
 			else
 				error("invalid param type")
 			end
@@ -563,6 +566,7 @@ local option_spec:{string:Option} = {
 					end,
 					"You may want to use --bibtex or --biber option."
 				}
+				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.bibtex)] = nil
 			else
 				error("invalid param type")
 			end
@@ -585,6 +589,7 @@ local option_spec:{string:Option} = {
 					end,
 					"You may want to use --bibtex or --biber option."
 				}
+				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.biber)] = nil
 			else
 				error("invalid param type")
 			end
@@ -606,6 +611,7 @@ local option_spec:{string:Option} = {
 					end,
 					"You may want to use --sagetex option."
 				}
+				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.sagetex)] = nil
 			else
 				error("invalid param type")
 			end
@@ -693,6 +699,7 @@ local option_spec:{string:Option} = {
 					end,
 					"You may want to use --memoize option."
 				}
+				options.hooks.suggestion_execlog_based[assert(option_t.hook_prios.suggestion_execlog_based.memoize)] = nil
 			else
 				error("invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -600,6 +600,8 @@ local option_spec:{string:Option} = {
 			if param is string then
 				options.glossaries = options.glossaries or {}
 				table.insert(options.glossaries, assert(parse_glossaries_option_from_string(param)))
+				options.hooks = options.hooks or option_t.init_hooks()
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.glossaries)] = {typeset_hooks.glossaries, "glossaries"}
 			else
 				error("invalid param type")
 			end
@@ -640,6 +642,8 @@ local option_spec:{string:Option} = {
 
 			options.glossaries = options.glossaries or {}
 			table.insert(options.glossaries, assert(parse_glossaries_option_from_table(param)))
+			options.hooks = options.hooks or option_t.init_hooks()
+			options.hooks.post_compile[assert(option_t.hook_prios.post_compile.glossaries)] = {typeset_hooks.glossaries, "glossaries"}
 		end,
 	},
 	memoize = {

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -477,7 +477,7 @@ local option_spec:{string:Option} = {
 					o.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.package_support)+0.1] = {typeset_hooks.ps_minted, "package_support minted"}
 					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.1] = {
 						function(fileinfo:common_t.Filemap_ele): boolean
-								return string.match(fileinfo.path, "minted/minted%.sty$") ~= nil
+								return string.find(fileinfo.path, "minted/minted%.sty$") ~= nil
 						end,
 						"You may want to use --package-support=minted option."
 					}
@@ -488,7 +488,7 @@ local option_spec:{string:Option} = {
 					o.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.package_support)+0.2] = {typeset_hooks.ps_epstopdf, "package_support epstopdf"}
 					o.hooks.suggestion_file_based[assert(option_t.hook_prios.suggestion_file_based.package_support)+0.2] = {
 						function(fileinfo:common_t.Filemap_ele): boolean
-								return string.match(fileinfo.path, "epstopdf%.sty$") ~= nil
+								return string.find(fileinfo.path, "epstopdf%.sty$") ~= nil
 						end,
 						"You may want to use --package-support=epstopdf option."
 					}

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -46,7 +46,7 @@ local function init_hooks(o:option_t.Options, spec:{string:Option})
 	-- o.hooks.pre_compile              = {}
 	o.hooks.post_compile             = {}
 	-- o.hooks.pre_build                = {}
-	-- o.hooks.post_build               = {}
+	o.hooks.post_build               = {}
 	o.hooks.suggestion_file_based    = {}
 	o.hooks.suggestion_execlog_based = {}
 

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -646,6 +646,8 @@ local option_spec:{string:Option} = {
 				else
 					options.memoize = param
 				end
+				options.hooks = options.hooks or option_t.init_hooks()
+				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.memoize+0.1)] = {typeset_hooks.memoize, "memoize"}
 			else
 				error("invalid param type")
 			end
@@ -658,6 +660,8 @@ local option_spec:{string:Option} = {
 			if param is string then
 				options.memoize_opts = options.memoize_opts or {}
 				table.insert(options.memoize_opts, param)
+				options.hooks = options.hooks or option_t.init_hooks()
+				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.memoize-0.2)] = {typeset_hooks.memoize_opts, "memoize_opts"}
 			else
 				error("invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -517,6 +517,8 @@ local option_spec:{string:Option} = {
 			assert(param == "dvipdfmx" or param == "dvips" or param == "dvisvgm", "wrong value for --check-driver option")
 			if param is string then
 				options.check_driver = param
+				options.hooks = options.hooks or option_t.init_hooks()
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.check_driver)] = {typeset_hooks.check_driver, "check_driver"}
 			else
 				assert(param is string, "invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -675,6 +675,8 @@ local option_spec:{string:Option} = {
 			assert(options.quiet == nil, "multiple --quiet options")
 			if param is string then
 				options.quiet = assert(tonumber(param) as integer, "parameter must be an integer")
+				options.hooks = options.hooks or option_t.init_hooks()
+				options.hooks.tex_injection[assert(option_t.hook_prios.tex_injection.quiet)] = {typeset_hooks.quiet, "quiet"}
 			else
 				error("invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -565,6 +565,8 @@ local option_spec:{string:Option} = {
 			assert(options.bibtex == nil, "multiple --bibtex/--biber options")
 			if param is string then
 				options.biber = param
+				options.hooks = options.hooks or option_t.init_hooks()
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.biber)] = {typeset_hooks.biber, "biber"}
 			else
 				error("invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -531,6 +531,8 @@ local option_spec:{string:Option} = {
 			assert(options.makeindex == nil, "multiple --makeindex options")
 			if param is string then
 				options.makeindex = param
+				options.hooks = options.hooks or option_t.init_hooks()
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.makeindex)] = {typeset_hooks.makeindex, "makeindex"}
 			else
 				error("invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -549,6 +549,8 @@ local option_spec:{string:Option} = {
 			assert(options.biber == nil, "multiple --bibtex/--biber options")
 			if param is string then
 				options.bibtex = param
+				options.hooks = options.hooks or option_t.init_hooks()
+				options.hooks.post_compile[assert(option_t.hook_prios.post_compile.bibtex)] = {typeset_hooks.bibtex, "bibtex"}
 			else
 				error("invalid param type")
 			end

--- a/src_teal/texrunner/option_spec.tl
+++ b/src_teal/texrunner/option_spec.tl
@@ -30,6 +30,12 @@ local record Module
 	spec:{string:Option}
 	usage:function({string})
 	init_hooks: function(option_t.Options, {string:Option})
+	_internal: Internal
+	record Internal
+		split: function(opt:string): {string}
+		parse_glossaries_option_from_table: function(opt:{string:string|nil}): option_t.Glos, string
+		parse_glossaries_option_from_string: function(opt:string): option_t.Glos, string
+	end
 end
 local _M:Module = {}
 
@@ -965,5 +971,14 @@ local spec = {
 _M.init_hooks = init_hooks
 _M.spec = spec
 _M.usage = usage
+
+
+if CLUTTEALTEX_TEST_ENV then
+	_M._internal = {
+		split                               = split,
+		parse_glossaries_option_from_table  = parse_glossaries_option_from_table,
+		parse_glossaries_option_from_string = parse_glossaries_option_from_string,
+	}
+end
 
 return _M

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -78,7 +78,8 @@ local record Module
 		-- (potentially includes multiple invocations to *TeX and other tools
 		-- like makeindex or biber)
 		-- pre_build: {number: function}
-		-- post_build: {number: function}
+		type post_build_func = function(Options)
+		post_build: {number: {post_build_func,string}}
 
 		-- hooks which run when a recorder file is being parsed before running
 		-- *TeX in order to suggest some options based on the files from the
@@ -106,7 +107,7 @@ local record Module
 		post_compile:          HookPriosTab
 
 		-- pre_build:             HookPriosTab
-		-- post_build:            HookPriosTab
+		post_build:            HookPriosTab
 	end
 
 	-- argument collections related to special hooks
@@ -147,7 +148,8 @@ local _M: Module = {
 			biber       = 5,
 			memoize     = 6,
 			sagetex     = 7,
-		}
+		},
+		post_build = {},
 	},
 }
 return _M

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -103,7 +103,6 @@ local record Module
 		-- pre_build:             {string: integer}
 		-- post_build:            {string: integer}
 	end
-	init_hooks: function(): Hooks
 
 	-- argument collections related to special hooks
 	record PostCompileArgs
@@ -145,14 +144,5 @@ local _M: Module = {
 			sagetex     = 7,
 		}
 	},
-	init_hooks = function():Module.Hooks return {
-		tex_injection            = {},
-		-- pre_compile              = {},
-		post_compile             = {},
-		-- pre_build                = {},
-		-- post_build               = {},
-		suggestion_file_based    = {},
-		suggestion_execlog_based = {},
-	} end
 }
 return _M

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -84,6 +84,9 @@ local record Module
 		-- the third value in the tuple is used to store if the message (second
 		-- value in the tuple) has already been shown to the user
 		suggestion_file_based: {number: {(function(common_t.Filemap_ele):boolean), string, boolean}}
+
+		-- hooks which check the execlog if some option should be probably used
+		suggestion_execlog_based: {number: {(function(string, Options):boolean), string}}
 	end
 
 	-- stores the allocated priorities
@@ -91,7 +94,8 @@ local record Module
 	record HookPrios
 		tex_injection:         {string: integer}
 
-		suggestion_file_based: {string: integer}
+		suggestion_file_based:    {string: integer}
+		suggestion_execlog_based: {string: integer}
 
 		pre_compile:           {string: integer}
 		post_compile:          {string: integer}
@@ -123,6 +127,15 @@ local _M: Module = {
 			package_support = 2,
 		},
 		post_compile = {
+			checkdriver = 1,
+			makeindex   = 2,
+			glossaries  = 3,
+			bibtex      = 4,
+			biber       = 5,
+			memoize     = 6,
+			sagetex     = 7,
+		},
+		suggestion_execlog_based = {
 			checkdriver = 1,
 			makeindex   = 2,
 			glossaries  = 3,

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -69,14 +69,14 @@ local record Module
 		tex_injection: {number: {(function(options:Options, engine_t.Option, tex_injection: string): string), string}}
 
 		-- hooks which are run before/after every *TeX invocation
-		pre_compile: {number: function}
+		-- pre_compile: {number: function}
 		post_compile: {number: {(function(Options, PostCompileArgs)), string}}
 
 		-- hooks which are run before/after every the whole build procedure
 		-- (potentially includes multiple invocations to *TeX and other tools
 		-- like makeindex or biber)
-		pre_build: {number: function}
-		post_build: {number: function}
+		-- pre_build: {number: function}
+		-- post_build: {number: function}
 
 		-- hooks which run when a recorder file is being parsed before running
 		-- *TeX in order to suggest some options based on the files from the
@@ -97,11 +97,11 @@ local record Module
 		suggestion_file_based:    {string: integer}
 		suggestion_execlog_based: {string: integer}
 
-		pre_compile:           {string: integer}
+		-- pre_compile:           {string: integer}
 		post_compile:          {string: integer}
 
-		pre_build:             {string: integer}
-		post_build:            {string: integer}
+		-- pre_build:             {string: integer}
+		-- post_build:            {string: integer}
 	end
 	init_hooks: function(): Hooks
 
@@ -147,10 +147,10 @@ local _M: Module = {
 	},
 	init_hooks = function():Module.Hooks return {
 		tex_injection            = {},
-		pre_compile              = {},
+		-- pre_compile              = {},
 		post_compile             = {},
-		pre_build                = {},
-		post_build               = {},
+		-- pre_build                = {},
+		-- post_build               = {},
 		suggestion_file_based    = {},
 		suggestion_execlog_based = {},
 	} end

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -73,7 +73,7 @@ local record Module
 
 		-- hooks which are run before/after every the whole build procedure
 		-- (potentially includes multiple invocations to *TeX and other tools
-		-- like makeindex or biber
+		-- like makeindex or biber)
 		pre_build: {number: function}
 		post_build: {number: function}
 	end

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -1,3 +1,5 @@
+local common_t = require"texrunner.common_types"
+
 local record Module
 	record Options
 		biber: string

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -1,4 +1,5 @@
 local common_t = require"texrunner.common_types"
+local engine_t = require"texrunner.tex_engine"
 
 local record Module
 	record Options
@@ -65,7 +66,7 @@ local record Module
 	record Hooks
 		-- hooks used to inject code into the *TeX input
 		-- hooks need to return the new tex_injection string (usually they should only prepend/append)
-		tex_injection: {number: {(function(options:Options, tex_injection: string): string), string}}
+		tex_injection: {number: {(function(options:Options, engine_t.Option, tex_injection: string): string), string}}
 
 		-- hooks which are run before/after every *TeX invocation
 		pre_compile: {number: function}

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -37,25 +37,68 @@ local record Module
 		memoize_opts: {string}
 		extraoptions: {string}
 		quiet: integer
+
+		hooks: Hooks
 	end
 	record WatchIncExc
 		type: string
 		param: string
 	end
 	record Glos
-		type: string -- only used for splitting and cmd building
-		out: string -- used during compilation
-		inp: string -- used during compilation
-		log: string -- only used for splitting and cmd building
-		path: string -- only used for splitting and cmd building
-
+		-- only used for splitting and cmd building
+		type: string
+		log: string
+		path: string
+		-- used during compilation
+		out: string
+		inp: string
 		-- used during compilation
 		-- takes the name of the inputfile as an argument and returns the
 		-- formatted command
 		cmd: function(function(string):string): string
 	end
 
+	-- hooks are always associated with a priority and a descriptive string
+	-- a low number means a high priority -> is executed first
+	record Hooks
+		-- hooks used to inject code into the *TeX input
+		-- hooks need to return the new tex_injection string (usually they should only prepend/append)
+		tex_injection: {number: {(function(options:Options, tex_injection: string): string), string}}
+
+		-- hooks which are run before/after every *TeX invocation
+		pre_compile: {number: function}
+		post_compile: {number: function}
+
+		-- hooks which are run before/after every the whole build procedure
+		-- (potentially includes multiple invocations to *TeX and other tools
+		-- like makeindex or biber
+		pre_build: {number: function}
+		post_build: {number: function}
+	end
+
+	-- stores the allocated priorities
+	hook_prios: HookPrios
+	record HookPrios
+		tex_injection: {string: integer}
+	end
+	init_hooks: function(): Hooks
 end
 
-local _M: Module = {}
+local _M: Module = {
+	hook_prios = {
+		tex_injection = {
+			includeonly     = 1,
+			package_support = 2,
+			memoize         = 3,
+			quiet           = 4,
+		}
+	},
+	init_hooks = function():Module.Hooks return {
+		tex_injection = {},
+		pre_compile   = {},
+		post_compile  = {},
+		pre_build     = {},
+		post_build    = {},
+	} end
+}
 return _M

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -76,12 +76,20 @@ local record Module
 		-- like makeindex or biber)
 		pre_build: {number: function}
 		post_build: {number: function}
+
+		-- hooks which run when a recorder file is being parsed before running
+		-- *TeX in order to suggest some options based on the files from the
+		-- filelist
+		-- the third value in the tuple is used to store if the message (second
+		-- value in the tuple) has already been shown to the user
+		suggestion_file_based: {number: {(function(common_t.Filemap_ele):boolean), string, boolean}}
 	end
 
 	-- stores the allocated priorities
 	hook_prios: HookPrios
 	record HookPrios
-		tex_injection: {string: integer}
+		tex_injection:         {string: integer}
+		suggestion_file_based: {string: integer}
 	end
 	init_hooks: function(): Hooks
 end
@@ -93,14 +101,18 @@ local _M: Module = {
 			package_support = 2,
 			memoize         = 3,
 			quiet           = 4,
-		}
+		},
+		suggestion_file_based = {
+			package_support = 2,
+		},
 	},
 	init_hooks = function():Module.Hooks return {
-		tex_injection = {},
-		pre_compile   = {},
-		post_compile  = {},
-		pre_build     = {},
-		post_build    = {},
+		tex_injection         = {},
+		pre_compile           = {},
+		post_compile          = {},
+		pre_build             = {},
+		post_build            = {},
+		suggestion_file_based = {},
 	} end
 }
 return _M

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -66,11 +66,13 @@ local record Module
 	record Hooks
 		-- hooks used to inject code into the *TeX input
 		-- hooks need to return the new tex_injection string (usually they should only prepend/append)
-		tex_injection: {number: {(function(options:Options, engine_t.Option, tex_injection: string): string), string}}
+		type tex_injection_func = function(options:Options, engine_t.Option, tex_injection: string): string
+		tex_injection: {number: {tex_injection_func, string}}
 
 		-- hooks which are run before/after every *TeX invocation
 		-- pre_compile: {number: function}
-		post_compile: {number: {(function(Options, PostCompileArgs)), string}}
+		type post_compile_func = function(Options, PostCompileArgs)
+		post_compile: {number: {post_compile_func, string}}
 
 		-- hooks which are run before/after every the whole build procedure
 		-- (potentially includes multiple invocations to *TeX and other tools
@@ -83,31 +85,34 @@ local record Module
 		-- filelist
 		-- the third value in the tuple is used to store if the message (second
 		-- value in the tuple) has already been shown to the user
-		suggestion_file_based: {number: {(function(common_t.Filemap_ele):boolean), string, boolean}}
+		type suggestion_file_based_func = function(common_t.Filemap_ele):boolean
+		suggestion_file_based: {number: {suggestion_file_based_func, string, boolean}}
 
 		-- hooks which check the execlog if some option should be probably used
-		suggestion_execlog_based: {number: {(function(string, Options):boolean), string}}
+		type suggestion_execlog_based_func = function(string, Options):boolean
+		suggestion_execlog_based: {number: {suggestion_execlog_based_func, string}}
 	end
 
 	-- stores the allocated priorities
 	hook_prios: HookPrios
+	type HookPriosTab = {string:integer}
 	record HookPrios
-		tex_injection:         {string: integer}
+		tex_injection:         HookPriosTab
 
-		suggestion_file_based:    {string: integer}
-		suggestion_execlog_based: {string: integer}
+		suggestion_file_based:    HookPriosTab
+		suggestion_execlog_based: HookPriosTab
 
-		-- pre_compile:           {string: integer}
-		post_compile:          {string: integer}
+		-- pre_compile:           HookPriosTab
+		post_compile:          HookPriosTab
 
-		-- pre_build:             {string: integer}
-		-- post_build:            {string: integer}
+		-- pre_build:             HookPriosTab
+		-- post_build:            HookPriosTab
 	end
 
 	-- argument collections related to special hooks
 	record PostCompileArgs
-		filelist: {common_t.Filemap_ele}
-		auxstatus: {string: common_t.Status}
+		filelist: common_t.filelist
+		auxstatus: common_t.auxstatus
 		path_in_output_directory: function(string):string
 		bibtex_aux_hash: string
 		original_wd: string

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -70,7 +70,7 @@ local record Module
 
 		-- hooks which are run before/after every *TeX invocation
 		pre_compile: {number: function}
-		post_compile: {number: function}
+		post_compile: {number: {(function(Options, PostCompileArgs)), string}}
 
 		-- hooks which are run before/after every the whole build procedure
 		-- (potentially includes multiple invocations to *TeX and other tools
@@ -90,9 +90,25 @@ local record Module
 	hook_prios: HookPrios
 	record HookPrios
 		tex_injection:         {string: integer}
+
 		suggestion_file_based: {string: integer}
+
+		pre_compile:           {string: integer}
+		post_compile:          {string: integer}
+
+		pre_build:             {string: integer}
+		post_build:            {string: integer}
 	end
 	init_hooks: function(): Hooks
+
+	-- argument collections related to special hooks
+	record PostCompileArgs
+		filelist: {common_t.Filemap_ele}
+		auxstatus: {string: common_t.Status}
+		path_in_output_directory: function(string):string
+		bibtex_aux_hash: string
+		original_wd: string
+	end
 end
 
 local _M: Module = {
@@ -106,6 +122,15 @@ local _M: Module = {
 		suggestion_file_based = {
 			package_support = 2,
 		},
+		post_compile = {
+			checkdriver = 1,
+			makeindex   = 2,
+			glossaries  = 3,
+			bibtex      = 4,
+			biber       = 5,
+			memoize     = 6,
+			sagetex     = 7,
+		}
 	},
 	init_hooks = function():Module.Hooks return {
 		tex_injection         = {},

--- a/src_teal/texrunner/option_type.tl
+++ b/src_teal/texrunner/option_type.tl
@@ -146,12 +146,13 @@ local _M: Module = {
 		}
 	},
 	init_hooks = function():Module.Hooks return {
-		tex_injection         = {},
-		pre_compile           = {},
-		post_compile          = {},
-		pre_build             = {},
-		post_build            = {},
-		suggestion_file_based = {},
+		tex_injection            = {},
+		pre_compile              = {},
+		post_compile             = {},
+		pre_build                = {},
+		post_build               = {},
+		suggestion_file_based    = {},
+		suggestion_execlog_based = {},
 	} end
 }
 return _M

--- a/src_teal/texrunner/reruncheck.tl
+++ b/src_teal/texrunner/reruncheck.tl
@@ -43,16 +43,11 @@ local record Module
 		mtime: number
 		size:  number
 	end
-	record Status
-		mtime: number
-		size: number
-		md5sum: string
-	end
 
 	parse_recorder_file: function(string, option_t.Options, ?{common_t.Filemap_ele}, ?{string:common_t.Filemap_ele}): {common_t.Filemap_ele}, {string:common_t.Filemap_ele}
-	collectfileinfo: function({common_t.Filemap_ele}, {string:Module.Status}): {string:Module.Status}
-	comparefileinfo: function({common_t.Filemap_ele}, {string:Module.Status}): boolean, {string:Module.Status}
-	comparefiletime: function(string, string, {string:Module.Status}): boolean
+	collectfileinfo: function({common_t.Filemap_ele}, {string:common_t.Status}): {string:common_t.Status}
+	comparefileinfo: function({common_t.Filemap_ele}, {string:common_t.Status}): boolean, {string:common_t.Status}
+	comparefiletime: function(string, string, {string:common_t.Status}): boolean
 	anyNonOutputNewerThan: function(filelist:{common_t.Filemap_ele}, reference: string): boolean
 
 	_internal: Internal
@@ -62,8 +57,8 @@ local record Module
 		get_file_attributes:  function(path: string, get_mtime:boolean, get_size:boolean): fileAttrs
 		get_output_file_kind: function(ext: string, options: option_t.Options): common_t.FileKind
 		get_input_file_kind:  function(ext: string, options: option_t.Options): common_t.FileKind
-		check_input_file:     function(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
-		check_auxiliary_file: function(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
+		check_input_file:     function(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: common_t.Status}): boolean, common_t.Status
+		check_auxiliary_file: function(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: common_t.Status}): boolean, common_t.Status
 		parse_recorder_line:  function(line: string, options: option_t.Options, filelist: {common_t.Filemap_ele}, filemap: {string: common_t.Filemap_ele})
 	end
 end
@@ -204,7 +199,7 @@ local function parse_recorder_file(file: string, options: option_t.Options, file
 end
 
 -- Collect information about files in the file list
-local function collectfileinfo(filelist:{common_t.Filemap_ele}, auxstatus:{string:Module.Status}): {string:Module.Status}
+local function collectfileinfo(filelist:{common_t.Filemap_ele}, auxstatus:{string:common_t.Status}): {string:common_t.Status}
 	auxstatus = auxstatus or {}
 
 	for _,fileinfo in ipairs(filelist) do
@@ -230,7 +225,7 @@ local function collectfileinfo(filelist:{common_t.Filemap_ele}, auxstatus:{strin
 end
 
 -- Check if an input file has been updated
-local function check_input_file(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
+local function check_input_file(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: common_t.Status}): boolean, common_t.Status
 	local attrs = get_file_attributes(path, true, false)
 	local mtime = attrs.mtime
 
@@ -245,7 +240,7 @@ local function check_input_file(path: string, fileinfo: common_t.Filemap_ele, au
 end
 
 -- Check if an auxiliary file has been modified
-local function check_auxiliary_file(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
+local function check_auxiliary_file(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: common_t.Status}): boolean, common_t.Status
 	local status = auxstatus[path]
 	if status then
 		-- Handle size and MD5 changes
@@ -314,8 +309,8 @@ local function check_auxiliary_file(path: string, fileinfo: common_t.Filemap_ele
 end
 
 -- Compare file information for changes
-local function comparefileinfo(filelist: {common_t.Filemap_ele}, auxstatus: {string: Module.Status}): boolean, {string: Module.Status}
-	local newauxstatus: {string: Module.Status} = {}
+local function comparefileinfo(filelist: {common_t.Filemap_ele}, auxstatus: {string: common_t.Status}): boolean, {string: common_t.Status}
+	local newauxstatus: {string: common_t.Status} = {}
 
 	for _, fileinfo in ipairs(filelist) do
 		local path = fileinfo.abspath
@@ -346,7 +341,7 @@ local function comparefileinfo(filelist: {common_t.Filemap_ele}, auxstatus: {str
 end
 
 -- Check if one file is newer than another
-local function comparefiletime(srcpath:string, dstpath:string, auxstatus:{string:Module.Status}): boolean
+local function comparefiletime(srcpath:string, dstpath:string, auxstatus:{string:common_t.Status}): boolean
 	if not fsutil.isfile(dstpath) then
 		return true
 	end

--- a/src_teal/texrunner/reruncheck.tl
+++ b/src_teal/texrunner/reruncheck.tl
@@ -25,7 +25,8 @@ local md5 = require "md5"
 local fsutil = require "texrunner.fsutil"
 local pathutil = require "texrunner.pathutil"
 local message = require "texrunner.message"
-local options = require"texrunner.option_type"
+local option_t = require "texrunner.option_type"
+local common_t = require "texrunner.common_types"
 
 local exit: function(code:integer)
 global CLUTTEALTEX_TEST_ENV: boolean
@@ -37,10 +38,10 @@ end
 
 -- Module structure defining records and exported functions
 local record Module
-	record Filemap_ele
-		path: string
-		abspath: string
-		kind: FileKind
+	-- Record type for file attributes (modification time and size)
+	record fileAttrs
+		mtime: number
+		size:  number
 	end
 	record Status
 		mtime: number
@@ -48,22 +49,22 @@ local record Module
 		md5sum: string
 	end
 
-	parse_recorder_file: function(string, options.Options, ?{Module.Filemap_ele}, ?{string:Module.Filemap_ele}): {Module.Filemap_ele}, {string:Module.Filemap_ele}
-	collectfileinfo: function({Module.Filemap_ele}, {string:Module.Status}): {string:Module.Status}
-	comparefileinfo: function({Module.Filemap_ele}, {string:Module.Status}): boolean, {string:Module.Status}
+	parse_recorder_file: function(string, option_t.Options, ?{common_t.Filemap_ele}, ?{string:common_t.Filemap_ele}): {common_t.Filemap_ele}, {string:common_t.Filemap_ele}
+	collectfileinfo: function({common_t.Filemap_ele}, {string:Module.Status}): {string:Module.Status}
+	comparefileinfo: function({common_t.Filemap_ele}, {string:Module.Status}): boolean, {string:Module.Status}
 	comparefiletime: function(string, string, {string:Module.Status}): boolean
-	anyNonOutputNewerThan: function(filelist:{Module.Filemap_ele}, reference: string): boolean
+	anyNonOutputNewerThan: function(filelist:{common_t.Filemap_ele}, reference: string): boolean
 
 	_internal: Internal
 	record Internal
 		md5sum_file:          function(path:string): string
 		binarytohex:          function(s:string): string
 		get_file_attributes:  function(path: string, get_mtime:boolean, get_size:boolean): fileAttrs
-		get_output_file_kind: function(ext: string, options: options.Options): FileKind
-		get_input_file_kind:  function(ext: string, options: options.Options): FileKind
-		check_input_file:     function(path: string, fileinfo: Module.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
-		check_auxiliary_file: function(path: string, fileinfo: Module.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
-		parse_recorder_line:  function(line: string, options: options.Options, filelist: {Module.Filemap_ele}, filemap: {string: Module.Filemap_ele})
+		get_output_file_kind: function(ext: string, options: option_t.Options): common_t.FileKind
+		get_input_file_kind:  function(ext: string, options: option_t.Options): common_t.FileKind
+		check_input_file:     function(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
+		check_auxiliary_file: function(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
+		parse_recorder_line:  function(line: string, options: option_t.Options, filelist: {common_t.Filemap_ele}, filemap: {string: common_t.Filemap_ele})
 	end
 end
 
@@ -84,14 +85,8 @@ local function binarytohex(s:string): string
 	return r
 end
 
--- Record type for file attributes (modification time and size)
-local record fileAttrs
-	mtime: number
-	size:  number
-end
-
 -- Fetch file attributes (mtime, size)
-local function get_file_attributes(path: string, get_mtime:boolean, get_size:boolean): fileAttrs
+local function get_file_attributes(path: string, get_mtime:boolean, get_size:boolean): Module.fileAttrs
 	local mtime, size: any, any
 
 	if get_mtime then
@@ -111,15 +106,8 @@ local function get_file_attributes(path: string, get_mtime:boolean, get_size:boo
 	return {mtime = mtime as number, size = size as number}
 end
 
--- Enum representing types of files handled by the module
-local enum FileKind
-	"auxiliary"
-	"output"
-	"input"
-end
-
 -- Determine the kind of an output file based on its extension and options
-local function get_output_file_kind(ext: string, options: options.Options): FileKind
+local function get_output_file_kind(ext: string, options: option_t.Options): common_t.FileKind
 	if ext == "out" then
 		return "auxiliary" -- hyperref bookmarks
 	elseif options.makeindex and ext == "idx" then
@@ -141,7 +129,7 @@ local function get_output_file_kind(ext: string, options: options.Options): File
 end
 
 -- Determine the kind of an input file based on its extension and options
-local function get_input_file_kind(ext: string, options: options.Options): FileKind
+local function get_input_file_kind(ext: string, options: option_t.Options): common_t.FileKind
 	if ext == "bbl" then
 		return "auxiliary"
 	elseif options.glossaries then
@@ -156,7 +144,7 @@ local function get_input_file_kind(ext: string, options: options.Options): FileK
 end
 
 -- Parse a single line from the recorder file
-local function parse_recorder_line(line: string, options: options.Options, filelist: {Module.Filemap_ele}, filemap: {string: Module.Filemap_ele})
+local function parse_recorder_line(line: string, options: option_t.Options, filelist: {common_t.Filemap_ele}, filemap: {string: common_t.Filemap_ele})
 	local t, path = line:match("^(%w+) (.*)$")
 	if not t or not path then
 		message.warn("Unrecognized line in recorder file: ", line)
@@ -176,7 +164,7 @@ local function parse_recorder_line(line: string, options: options.Options, filel
 	local ext = pathutil.ext(path)
 	local fileinfo = filemap[abspath]
 
-	local kind:FileKind
+	local kind:common_t.FileKind
 	if t == "INPUT" then
 		kind = get_input_file_kind(ext, options)
 	else
@@ -203,7 +191,7 @@ local function parse_recorder_line(line: string, options: options.Options, filel
 end
 
 -- Parse the recorder file and build file lists/maps
-local function parse_recorder_file(file: string, options: options.Options, filelist?: {Module.Filemap_ele}, filemap?: {string: Module.Filemap_ele}): {Module.Filemap_ele}, {string: Module.Filemap_ele}
+local function parse_recorder_file(file: string, options: option_t.Options, filelist?: {common_t.Filemap_ele}, filemap?: {string: common_t.Filemap_ele}): {common_t.Filemap_ele}, {string: common_t.Filemap_ele}
 	-- init
 	filelist = filelist or {}
 	filemap = filemap or {}
@@ -216,7 +204,7 @@ local function parse_recorder_file(file: string, options: options.Options, filel
 end
 
 -- Collect information about files in the file list
-local function collectfileinfo(filelist:{Module.Filemap_ele}, auxstatus:{string:Module.Status}): {string:Module.Status}
+local function collectfileinfo(filelist:{common_t.Filemap_ele}, auxstatus:{string:Module.Status}): {string:Module.Status}
 	auxstatus = auxstatus or {}
 
 	for _,fileinfo in ipairs(filelist) do
@@ -242,7 +230,7 @@ local function collectfileinfo(filelist:{Module.Filemap_ele}, auxstatus:{string:
 end
 
 -- Check if an input file has been updated
-local function check_input_file(path: string, fileinfo: Module.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
+local function check_input_file(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
 	local attrs = get_file_attributes(path, true, false)
 	local mtime = attrs.mtime
 
@@ -257,7 +245,7 @@ local function check_input_file(path: string, fileinfo: Module.Filemap_ele, auxs
 end
 
 -- Check if an auxiliary file has been modified
-local function check_auxiliary_file(path: string, fileinfo: Module.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
+local function check_auxiliary_file(path: string, fileinfo: common_t.Filemap_ele, auxstatus: {string: Module.Status}): boolean, Module.Status
 	local status = auxstatus[path]
 	if status then
 		-- Handle size and MD5 changes
@@ -326,7 +314,7 @@ local function check_auxiliary_file(path: string, fileinfo: Module.Filemap_ele, 
 end
 
 -- Compare file information for changes
-local function comparefileinfo(filelist: {Module.Filemap_ele}, auxstatus: {string: Module.Status}): boolean, {string: Module.Status}
+local function comparefileinfo(filelist: {common_t.Filemap_ele}, auxstatus: {string: Module.Status}): boolean, {string: Module.Status}
 	local newauxstatus: {string: Module.Status} = {}
 
 	for _, fileinfo in ipairs(filelist) do
@@ -375,7 +363,7 @@ local function comparefiletime(srcpath:string, dstpath:string, auxstatus:{string
 end
 
 -- Check if any file in the list is newer than a reference file
-local function anyNonOutputNewerThan(filelist:{Module.Filemap_ele}, reference: string): boolean
+local function anyNonOutputNewerThan(filelist:{common_t.Filemap_ele}, reference: string): boolean
 	if not fsutil.isfile(reference) then
 		return true
 	end

--- a/src_teal/texrunner/reruncheck.tl
+++ b/src_teal/texrunner/reruncheck.tl
@@ -266,7 +266,7 @@ local function check_auxiliary_file(path: string, fileinfo: common_t.Filemap_ele
 		if really_modified then
 			message.info("File '", fileinfo.path, "' was modified (", modified_because, ").")
 			return true, status
-		elseif CLUTTEALTEX_VERBOSITY >= 1 then
+		elseif CLUTTEALTEX_VERBOSITY >= 2 then
 			message.info("File '", fileinfo.path, "' unmodified (size and md5sum).")
 		end
 	else

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -20,7 +20,6 @@ along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 
 -- External libraries (included in texlua)
 local md5     = require "md5"
-local filesys = require "lfs"
 
 local os                           = require"os_"
 local pathutil                     = require "texrunner.pathutil"
@@ -34,8 +33,8 @@ local extract_bibtex_from_aux_file = require "texrunner.auxfile".extract_bibtex_
 local safename                     = require "texrunner.safename"
 local recoverylib                  = require "texrunner.recovery"
 
-local option_t                     = require "texrunner.option_type"
 local common_t                     = require "texrunner.common_types"
+local ts_hooks                     = require "texrunner.typeset_hooks"
 
 local exit: function(code:integer)
 global CLUTTEALTEX_TEST_ENV: boolean
@@ -62,107 +61,6 @@ local record Module
 	end
 end
 
-local function hooks_sort_prios(hook_table: {number: {function, string}}): {number}
-	local priorities = {}
-	for prio in pairs(hook_table) do
-		table.insert(priorities, prio)
-	end
-	table.sort(priorities)
-	return priorities
-end
-
-local function hooks_validate(hook: {function, string, boolean}): boolean, string
-	if not hook or not hook[1] or not hook[2] then
-		return false, "Malformed hook"
-	end
-	return true, nil
-end
-
--- returns the new tex_injection string
-local function hooks_apply_tex_injection(hooks: {number: {option_t.Hooks.tex_injection_func, string}}, options: option_t.Options, tex_options: engine_t.Option, tex_injection:string): string
-	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
-	local result = tex_injection
-	for _, prio in ipairs(sorted_prios) do
-		local hook = hooks[prio]
-		local valid, err = hooks_validate(hook)
-		if not valid then
-			error("Invalid hook: " .. err)
-		end
-		 if CLUTTEALTEX_VERBOSITY >= 1 then
-			message.info("Executing tex_injection hook '", hook[2], "'")
-		end
-		result = hook[1](options, tex_options, result)
-	end
-	return result
-end
-
-local function hooks_apply_suggestion_file_based(hooks: {number: {option_t.Hooks.suggestion_file_based_func, string, boolean}}, filelist:{common_t.Filemap_ele})
-	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
-	-- check if all hooks are valid
-	for _, prio in ipairs(sorted_prios) do
-		local hook = hooks[prio]
-		local valid, err = hooks_validate(hook)
-		if not valid then
-			error("Invalid hook: " .. err)
-		end
-	end
-
-	-- run hooks on files contained in the filelist and emit messages
-	for _,fileinfo in ipairs(filelist) do
-		for _, prio in ipairs(sorted_prios) do
-			local hook = hooks[prio]
-			if not hook[3] and hook[1](fileinfo) then
-				message.diag(hook[2])
-				hook[3] = true
-			end
-		end
-	end
-end
-
-local function hooks_apply_suggestion_excelog_based(hooks: {number: {option_t.Hooks.suggestion_execlog_based_func, string}}, execlog: string, o:option_t.Options)
-	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
-	for _, prio in ipairs(sorted_prios) do
-		local hook = hooks[prio]
-		local valid, err = hooks_validate(hook)
-		if not valid then
-			error("Invalid hook: " .. err)
-		end
-		if hook[1](execlog, o) then
-			message.diag(hook[2])
-		end
-	end
-end
-
-local function hooks_apply_post_compile(hooks: {number: {option_t.Hooks.post_compile_func, string}}, options: option_t.Options, args: option_t.PostCompileArgs)
-	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
-	for _, prio in ipairs(sorted_prios) do
-		local hook = hooks[prio]
-		local valid, err = hooks_validate(hook)
-		if not valid then
-			error("Invalid hook: " .. err)
-		end
-		 if CLUTTEALTEX_VERBOSITY >= 1 then
-			message.info("Executing post_compile hook '", hook[2], "'")
-		end
-		hook[1](options, args)
-	end
-end
-
-local function hooks_apply_post_build(hooks: {number: {option_t.Hooks.post_build_func, string}}, options: option_t.Options)
-	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
-	for _, prio in ipairs(sorted_prios) do
-		local hook = hooks[prio]
-		local valid, err = hooks_validate(hook)
-		if not valid then
-			error("Invalid hook: " .. err)
-		end
-		 if CLUTTEALTEX_VERBOSITY >= 1 then
-			message.info("Executing post_build hook '", hook[2], "'")
-		end
-		hook[1](options)
-	end
-end
-
 -- Run TeX command (*tex, *latex)
 -- should_rerun, newauxstatus = single_run([auxstatus])
 -- This function should be run in a coroutine.
@@ -179,7 +77,7 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 
 		-- emits suggestsions to the user which options might be usefull
 		-- does nothing except potentially message.diag -> no return needed
-		hooks_apply_suggestion_file_based(args.options.hooks.suggestion_file_based, filelist)
+		ts_hooks.apply_suggestion_file_based(args.options.hooks.suggestion_file_based, filelist)
 
 		if args.options.bibtex then
 			local biblines = extract_bibtex_from_aux_file(mainauxfile, args.options.output_directory)
@@ -205,7 +103,7 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 	local tex_injection = args.tex_options.tex_injection or ""
 
 	-- run tex_injection hooks
-	tex_injection = hooks_apply_tex_injection(args.options.hooks.tex_injection, args.options, args.tex_options, tex_injection)
+	tex_injection = ts_hooks.apply_tex_injection(args.options.hooks.tex_injection, args.options, args.tex_options, tex_injection)
 
 	local inputline = tex_injection .. safename.safeinput(args.inputfile, args.engine)
 
@@ -261,7 +159,7 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 		logfile:close()
 	end
 
-	hooks_apply_post_compile(args.options.hooks.post_compile, args.options, {
+	ts_hooks.apply_post_compile(args.options.hooks.post_compile, args.options, {
 		filelist                 = filelist,
 		auxstatus                = args.auxstatus,
 		path_in_output_directory = args.path_in_output_directory,
@@ -269,7 +167,7 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 		original_wd              = args.original_wd,
 	})
 
-	hooks_apply_suggestion_excelog_based(args.options.hooks.suggestion_execlog_based, execlog, args.options)
+	ts_hooks.apply_suggestion_excelog_based(args.options.hooks.suggestion_execlog_based, execlog, args.options)
 
 	if string.find(execlog, "No pages of output.") then
 		return "No pages of output."
@@ -358,7 +256,7 @@ local function do_typeset_coroutine(args:Module.typesetArgs): string, function
 		f:close()
 	end
 
-	hooks_apply_post_build(args.options.hooks.post_build, args.options)
+	ts_hooks.apply_post_build(args.options.hooks.post_build, args.options)
 end
 
 local function do_typeset(args: Module.typesetArgs): boolean, string, integer

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -88,10 +88,10 @@ local function hooks_apply_tex_injection(hooks: {number: {option_t.Hooks.tex_inj
 		if not valid then
 			error("Invalid hook: " .. err)
 		end
-		result = hook[1](options, tex_options, result)
 		 if CLUTTEALTEX_VERBOSITY >= 1 then
 			message.info("Executing tex_injection hook '", hook[2], "'")
 		end
+		result = hook[1](options, tex_options, result)
 	end
 	return result
 end
@@ -141,10 +141,10 @@ local function hooks_apply_post_compile(hooks: {number: {option_t.Hooks.post_com
 		if not valid then
 			error("Invalid hook: " .. err)
 		end
-		hook[1](options, args)
 		 if CLUTTEALTEX_VERBOSITY >= 1 then
 			message.info("Executing post_compile hook '", hook[2], "'")
 		end
+		hook[1](options, args)
 	end
 end
 
@@ -156,10 +156,10 @@ local function hooks_apply_post_build(hooks: {number: {option_t.Hooks.post_build
 		if not valid then
 			error("Invalid hook: " .. err)
 		end
-		hook[1](options)
 		 if CLUTTEALTEX_VERBOSITY >= 1 then
 			message.info("Executing post_build hook '", hook[2], "'")
 		end
+		hook[1](options)
 	end
 end
 

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -148,6 +148,21 @@ local function hooks_apply_post_compile(hooks: {number: {option_t.Hooks.post_com
 	end
 end
 
+local function hooks_apply_post_build(hooks: {number: {option_t.Hooks.post_build_func, string}}, options: option_t.Options)
+	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
+	for _, prio in ipairs(sorted_prios) do
+		local hook = hooks[prio]
+		local valid, err = hooks_validate(hook)
+		if not valid then
+			error("Invalid hook: " .. err)
+		end
+		hook[1](options)
+		 if CLUTTEALTEX_VERBOSITY >= 1 then
+			message.info("Executing post_build hook '", hook[2], "'")
+		end
+	end
+end
+
 -- Run TeX command (*tex, *latex)
 -- should_rerun, newauxstatus = single_run([auxstatus])
 -- This function should be run in a coroutine.
@@ -342,6 +357,8 @@ local function do_typeset_coroutine(args:Module.typesetArgs): string, function
 		f:write("\n")
 		f:close()
 	end
+
+	hooks_apply_post_build(args.options.hooks.post_build, args.options)
 end
 
 local function do_typeset(args: Module.typesetArgs): boolean, string, integer

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -272,51 +272,6 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 
 	if args.options.bibtex then
 	elseif args.options.biber then
-		for _,file in ipairs(filelist) do
-			-- usual compilation with biber
-			-- tex     -> pdflatex tex -> aux,bcf,pdf,run.xml
-			-- bcf     -> biber bcf    -> bbl
-			-- tex,bbl -> pdflatex tex -> aux,bcf,pdf,run.xml
-			if pathutil.ext(file.path) == "bcf" then
-				-- Run biber if the .bcf file is new or updated
-				local bcffileinfo = {path = file.path, abspath = file.abspath, kind = "auxiliary"}
-				local output_bbl = pathutil.replaceext(file.abspath, "bbl")
-				local updated_dot_bib = false
-				-- get the .bib files, the bcf uses as input
-				for l in io.lines(file.abspath) do
-					local bib = string.match(l, "<bcf:datasource .*>(.*)</bcf:datasource>") -- might be unstable if biblatex adds e.g. a linebreak
-					if bib then
-						local bibfile = pathutil.join(args.original_wd, bib)
-						local succ, err = io.open(bibfile, "r") -- check if file is present, don't use touch to avoid triggering a rerun
-						if succ then
-							succ:close()
-							local updated_dot_bib_tmp = not reruncheck.comparefiletime(pathutil.abspath(mainauxfile), bibfile, args.auxstatus)
-							if updated_dot_bib_tmp then
-								message.info(bibfile.." is newer than aux")
-							end
-							updated_dot_bib = updated_dot_bib_tmp or updated_dot_bib
-						else
-							message.warn(bibfile .. " is not accessible (" .. err .. ")")
-						end
-					end
-				end
-				if updated_dot_bib or reruncheck.comparefileinfo({bcffileinfo}, args.auxstatus) or reruncheck.comparefiletime(file.abspath, output_bbl, args.auxstatus) then
-					local biber_command = {
-						args.options.biber, -- Do not escape options.biber to allow additional options
-						"--output-directory", shellutil.escape(args.options.output_directory),
-						pathutil.basename(file.abspath)
-					}
-					coroutine.yield(table.concat(biber_command, " "))
-					-- watch for changes in the bbl
-					table.insert(filelist, {path = output_bbl, abspath = output_bbl, kind = "auxiliary"})
-				else
-					local succ, err = filesys.touch(output_bbl)
-					if not succ then
-						message.warn("Failed to touch " .. output_bbl .. " (" .. err .. ")")
-					end
-				end
-			end
-		end
 	else
 		-- Check log file
 		if string.find(execlog, "No file [^\n]+%.bbl%.") then

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -103,7 +103,7 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 		args.auxstatus = {}
 	end
 
-	local tex_injection = ""
+	local tex_injection = args.tex_options.tex_injection or ""
 
 	if args.options.includeonly then
 		tex_injection = string.format("%s\\includeonly{%s}", args.tex_options.tex_injection or "", args.options.includeonly)

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -26,7 +26,7 @@ local os                           = require"os_"
 local pathutil                     = require "texrunner.pathutil"
 local checkdriver                  = require "texrunner.checkdriver".checkdriver
 local shellutil                    = require "texrunner.shellutil"
-local options                      = require "texrunner.option_type"
+local options                      = require "texrunner.option_type" -- legacy import
 local message                      = require "texrunner.message"
 local reruncheck                   = require "texrunner.reruncheck"
 local fsutil                       = require "texrunner.fsutil"
@@ -34,6 +34,8 @@ local engine_t                     = require "texrunner.tex_engine"
 local extract_bibtex_from_aux_file = require "texrunner.auxfile".extract_bibtex_from_aux_file
 local safename                     = require "texrunner.safename"
 local recoverylib                  = require "texrunner.recovery"
+
+local option_t                     = require "texrunner.option_type"
 
 local exit: function(code:integer)
 global CLUTTEALTEX_TEST_ENV: boolean
@@ -58,6 +60,37 @@ local record Module
 		tex_options:engine_t.Option
 		original_wd: string
 	end
+end
+
+local function hooks_sort_prios(hook_table: {number: {function, string}}): {number}
+	local priorities = {}
+	for prio in pairs(hook_table) do
+		table.insert(priorities, prio)
+	end
+	table.sort(priorities)
+	return priorities
+end
+
+local function hooks_validate(hook: {function, string}): boolean, string
+	if not hook or not hook[1] or not hook[2] then
+		return false, "Malformed hook"
+	end
+	return true, nil
+end
+
+-- returns the new tex_injection string
+local function hooks_apply_tex_injection(hooks: {number: {(function(option_t.Options, string):string), string}}, options: option_t.Options, tex_injection:string): string
+	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
+	local result = tex_injection
+	for _, prio in ipairs(sorted_prios) do
+		local hook = hooks[prio]
+		local valid, err = hooks_validate(hook)
+		if not valid then
+			error("Invalid hook: " .. err)
+		end
+		result = hook[1](options, result)
+	end
+	return result
 end
 
 -- Run TeX command (*tex, *latex)
@@ -105,27 +138,8 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 
 	local tex_injection = args.tex_options.tex_injection or ""
 
-	-- collect hook priorities
-	local hook_prios = {}
-	for prio in pairs(args.options.hooks.tex_injection) do
-		table.insert(hook_prios, prio)
-	end
-	-- sort the priorities in order to execute them in the right order
-	table.sort(hook_prios)
-	for _,prio in ipairs(hook_prios) do
-		local h = args.options.hooks.tex_injection[prio]
-		-- check if hook is valid
-		if not h or not h[1] or not h[2] then
-			message.error("Malformed hook: h[1]: ", h[1], " h[2]: ", h[2])
-			exit(1)
-		else
-			-- execute hook
-			if CLUTTEALTEX_VERBOSITY >= 1 then
-				message.info("Executing tex_injection hook '", h[2], "'")
-			end
-			tex_injection = h[1](args.options, tex_injection)
-		end
-	end
+	-- run tex_injection hooks
+	tex_injection = hooks_apply_tex_injection(args.options.hooks.tex_injection, args.options, tex_injection)
 
 	if minted or args.options.package_support["minted"] then
 		local outdir = args.options.output_directory

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -248,26 +248,6 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 	end
 
 	if args.options.glossaries then
-		-- Look for configured files and run makeindex/xindy
-		for _,file in ipairs(filelist) do
-			for _, cfg in ipairs(args.options.glossaries) do
-				if pathutil.ext(file.path) == cfg.inp then
-					-- Run xindy/makeindex if the specified input-file is new or updated
-					local inputfileinfo = {path = file.path, abspath = file.abspath, kind = "auxiliary"}
-					local outputfile = args.path_in_output_directory(cfg.out)
-					if reruncheck.comparefileinfo({inputfileinfo}, args.auxstatus) or reruncheck.comparefiletime(file.abspath, outputfile, args.auxstatus) then
-						print(cfg.cmd(args.path_in_output_directory))
-						coroutine.yield(cfg.cmd(args.path_in_output_directory))
-						table.insert(filelist, {path = outputfile, abspath = outputfile, kind = "auxiliary"})
-					else
-						local succ, err = filesys.touch(outputfile)
-						if not succ then
-							message.warn("Failed to touch " .. outputfile .. " (" .. err .. ")")
-						end
-					end
-				end
-			end
-		end
 	end
 
 	if args.options.bibtex then

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -49,7 +49,7 @@ end
 local record Module
 	get_typesetter: function(args: Module.typesetArgs): (function(): boolean, string, integer, {common_t.Filemap_ele})
 	record typesetArgs
-		auxstatus:{string:reruncheck.Status}
+		auxstatus:{string:common_t.Status}
 		iteration:integer
 		path_in_output_directory: function(string): string
 		recorderfile: string

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -90,6 +90,9 @@ local function hooks_apply_tex_injection(hooks: {number: {(function(option_t.Opt
 			error("Invalid hook: " .. err)
 		end
 		result = hook[1](options, result)
+		 if CLUTTEALTEX_VERBOSITY >= 1 then
+			message.info("Executing tex_injection hook '", hook[2], "'")
+		end
 	end
 	return result
 end

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -135,6 +135,7 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 		args.auxstatus = reruncheck.collectfileinfo(filelist, args.auxstatus)
 
 		-- emits suggestsions to the user which options might be usefull
+		-- does nothing except potentially message.diag -> no return needed
 		hooks_apply_suggestion_file_based(args.options.hooks.suggestion_file_based, filelist)
 
 		if args.options.bibtex then
@@ -162,16 +163,6 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 
 	-- run tex_injection hooks
 	tex_injection = hooks_apply_tex_injection(args.options.hooks.tex_injection, args.options, args.tex_options, tex_injection)
-
-	if args.options.quiet then
-		if args.options.quiet >= 1 then
-			tex_injection = string.format("%s\\AddToHook{begindocument/end}[quietX]{\\hbadness=99999 \\hfuzz=9999pt}", tex_injection or "")
-		end
-		if args.options.quiet >= 2 then
-			args.tex_options.interaction = "batchmode"
-			tex_injection = string.format("%s\\AddToHook{begindocument/end}[quiet]{\\nonstopmode}\\AddToHook{enddocument/info}[quiet]{\\batchmode}", tex_injection or "")
-		end
-	end
 
 	local inputline = tex_injection .. safename.safeinput(args.inputfile, args.engine)
 

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -313,30 +313,6 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 	end
 
 	if args.options.sagetex then
-		for _,file in ipairs(filelist) do
-			-- usual compilation with sagetex
-			-- tex      -> pdflatex tex -> aux,pdf,sage
-			-- sage     -> sage sage    -> sout (eps)
-			-- tex,sout -> pdflatex tex -> aux,pdf,sage
-			local output_sout = pathutil.replaceext(file.abspath, "sout")
-			if pathutil.ext(file.path) == "sage" then
-				local sagefileinfo = {path = file.path, abspath = file.abspath, kind = "auxiliary"}
-				if reruncheck.comparefileinfo({sagefileinfo}, args.auxstatus) then
-					local sage_command = {
-						args.options.sagetex, -- Do not escape options.sagetex to allow additional options
-						pathutil.basename(file.abspath)
-					}
-					coroutine.yield(table.concat(sage_command, " "))
-					-- watch for changes in .sage
-					table.insert(filelist, {path = output_sout, abspath = output_sout, kind = "auxiliary"})
-				else
-					local succ, err = filesys.touch(output_sout)
-					if not succ then
-						message.warn("Failed to touch " .. output_sout .. " (" .. err .. ")")
-					end
-				end
-			end
-		end
 	else
 		-- Check log file
 		if string.find(execlog, "Run Sage on") then

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -232,36 +232,15 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 		logfile:close()
 	end
 
-	if args.options.check_driver ~= nil then
-		checkdriver(args.options.check_driver, filelist)
-	end
+	hooks_apply_post_compile(args.options.hooks.post_compile, args.options, {
+		filelist                 = filelist,
+		auxstatus                = args.auxstatus,
+		path_in_output_directory = args.path_in_output_directory,
+		bibtex_aux_hash          = bibtex_aux_hash,
+		original_wd              = args.original_wd,
+	})
 
-	if args.options.makeindex then
-		-- Look for .idx files and run MakeIndex
-		for _,file in ipairs(filelist) do
-			if pathutil.ext(file.path) == "idx" then
-				-- Run makeindex if the .idx file is new or updated
-				local idxfileinfo = {path = file.path, abspath = file.abspath, kind = "auxiliary"}
-				local output_ind = pathutil.replaceext(file.abspath, "ind")
-				if reruncheck.comparefileinfo({idxfileinfo}, args.auxstatus) or reruncheck.comparefiletime(file.abspath, output_ind, args.auxstatus) then
-					local idx_dir = pathutil.dirname(file.abspath)
-					local makeindex_command = {
-						"cd", shellutil.escape(idx_dir), "&&",
-						args.options.makeindex, -- Do not escape options.makeindex to allow additional options
-						"-o", pathutil.basename(output_ind),
-						pathutil.basename(file.abspath)
-					}
-					coroutine.yield(table.concat(makeindex_command, " "))
-					table.insert(filelist, {path = output_ind, abspath = output_ind, kind = "auxiliary"})
-				else
-					local succ, err = filesys.touch(output_ind)
-					if not succ then
-						message.warn("Failed to touch " .. output_ind .. " (" .. err .. ")")
-					end
-				end
-			end
-		end
-	else
+	if not args.options.makeindex then
 		-- Check log file
 		if string.find(execlog, "No file [^\n]+%.ind%.") then
 			message.diag("You may want to use --makeindex option.")

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -80,7 +80,7 @@ local function hooks_validate(hook: {function, string, boolean}): boolean, strin
 end
 
 -- returns the new tex_injection string
-local function hooks_apply_tex_injection(hooks: {number: {(function(option_t.Options, string):string), string}}, options: option_t.Options, tex_injection:string): string
+local function hooks_apply_tex_injection(hooks: {number: {(function(option_t.Options, engine_t.Option, string):string), string}}, options: option_t.Options, tex_options: engine_t.Option, tex_injection:string): string
 	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
 	local result = tex_injection
 	for _, prio in ipairs(sorted_prios) do
@@ -89,7 +89,7 @@ local function hooks_apply_tex_injection(hooks: {number: {(function(option_t.Opt
 		if not valid then
 			error("Invalid hook: " .. err)
 		end
-		result = hook[1](options, result)
+		result = hook[1](options, tex_options, result)
 		 if CLUTTEALTEX_VERBOSITY >= 1 then
 			message.info("Executing tex_injection hook '", hook[2], "'")
 		end
@@ -161,7 +161,7 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 	local tex_injection = args.tex_options.tex_injection or ""
 
 	-- run tex_injection hooks
-	tex_injection = hooks_apply_tex_injection(args.options.hooks.tex_injection, args.options, tex_injection)
+	tex_injection = hooks_apply_tex_injection(args.options.hooks.tex_injection, args.options, args.tex_options, tex_injection)
 
 	if args.options.quiet then
 		if args.options.quiet >= 1 then

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -260,31 +260,6 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 	end
 
 	if args.options.memoize then
-		for _,file in ipairs(filelist) do
-			-- usual compilation with memoize
-			-- tex      -> pdflatex tex    -> aux,pdf,mmz
-			-- mmz,pdf  -> memoize-extract -> pdf,pdf
-			-- tex      -> pdflatex tex    -> aux,pdf
-			if pathutil.ext(file.path) == "mmz" then
-				local must_extract = false
-				for l in io.lines(file.abspath) do
-					local newExtern = string.match(l, "^\\mmzNewExtern")
-					must_extract = must_extract or newExtern ~= nil
-				end
-				if must_extract then
-					local extract_command = {
-						args.options.memoize, -- Do not escape options.memoize to allow additional options
-						pathutil.basename(pathutil.replaceext(file.abspath, "tex"))
-					}
-					coroutine.yield(table.concat(extract_command, " "))
-					-- ensure document gets recompiled afterwards
-					local succ, err = filesys.touch(file.path)
-					if not succ then
-						message.warn("Failed to touch " .. file.path .. " (" .. err .. ")")
-					end
-				end
-			end
-		end
 	else
 		-- Check log file
 		if string.find(execlog, "Package memoize Warning") then

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -72,7 +72,7 @@ local function hooks_sort_prios(hook_table: {number: {function, string}}): {numb
 	return priorities
 end
 
-local function hooks_validate(hook: {function, string}): boolean, string
+local function hooks_validate(hook: {function, string, boolean}): boolean, string
 	if not hook or not hook[1] or not hook[2] then
 		return false, "Malformed hook"
 	end
@@ -97,11 +97,33 @@ local function hooks_apply_tex_injection(hooks: {number: {(function(option_t.Opt
 	return result
 end
 
+local function hooks_apply_suggestion_file_based(hooks: {number: {(function(common_t.Filemap_ele):boolean), string, boolean}}, filelist:{common_t.Filemap_ele})
+	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
+	-- check if all hooks are valid
+	for _, prio in ipairs(sorted_prios) do
+		local hook = hooks[prio]
+		local valid, err = hooks_validate(hook)
+		if not valid then
+			error("Invalid hook: " .. err)
+		end
+	end
+
+	-- run hooks on files contained in the filelist and emit messages
+	for _,fileinfo in ipairs(filelist) do
+		for _, prio in ipairs(sorted_prios) do
+			local hook = hooks[prio]
+			if not hook[3] and hook[1](fileinfo) then
+				message.diag(hook[2])
+				hook[3] = true
+			end
+		end
+	end
+end
+
 -- Run TeX command (*tex, *latex)
 -- should_rerun, newauxstatus = single_run([auxstatus])
 -- This function should be run in a coroutine.
 local function single_run_coroutine(args: Module.typesetArgs): boolean|string
-	local minted, epstopdf = false, false
 	local bibtex_aux_hash:string = nil
 	local mainauxfile = args.path_in_output_directory("aux")
 	if fsutil.isfile(args.recorderfile) then
@@ -111,14 +133,10 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 			filelist, filemap = reruncheck.parse_recorder_file(args.recorderfile2, args.options, filelist, filemap)
 		end
 		args.auxstatus = reruncheck.collectfileinfo(filelist, args.auxstatus)
-		for _,fileinfo in ipairs(filelist) do
-			if string.match(fileinfo.path, "minted/minted%.sty$") then
-				minted = true
-			end
-			if string.match(fileinfo.path, "epstopdf%.sty$") then
-				epstopdf = true
-			end
-		end
+
+		-- emits suggestsions to the user which options might be usefull
+		hooks_apply_suggestion_file_based(args.options.hooks.suggestion_file_based, filelist)
+
 		if args.options.bibtex then
 			local biblines = extract_bibtex_from_aux_file(mainauxfile, args.options.output_directory)
 			if #biblines > 0 then
@@ -145,29 +163,6 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 	-- run tex_injection hooks
 	tex_injection = hooks_apply_tex_injection(args.options.hooks.tex_injection, args.options, tex_injection)
 
-	if minted or args.options.package_support["minted"] then
-		local outdir = args.options.output_directory
-		if os.type == "windows" then
-			outdir = string.gsub(outdir, "\\", "/") -- Use forward slashes
-		end
-		tex_injection = string.format("%s\\PassOptionsToPackage{outputdir=%s}{minted}", tex_injection or "", outdir)
-		if not args.options.package_support["minted"] then
-			message.diag("You may want to use --package-support=minted option.")
-		end
-	end
-	if epstopdf or args.options.package_support["epstopdf"] then
-		local outdir = args.options.output_directory
-		if os.type == "windows" then
-			outdir = string.gsub(outdir, "\\", "/") -- Use forward slashes
-		end
-		if string.sub(outdir, -1, -1) ~= "/" then
-			outdir = outdir.."/" -- Must end with a directory separator
-		end
-		tex_injection = string.format("%s\\PassOptionsToPackage{outdir=%s}{epstopdf}", tex_injection or "", outdir)
-		if not args.options.package_support["epstopdf"] then
-			message.diag("You may want to use --package-support=epstopdf option.")
-		end
-	end
 	if args.options.memoize then
 		tex_injection = string.format("%s\\PassOptionsToPackage{no memo dir,extract=no}{memoize}", tex_injection or "")
 	end

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -24,7 +24,6 @@ local filesys = require "lfs"
 
 local os                           = require"os_"
 local pathutil                     = require "texrunner.pathutil"
-local checkdriver                  = require "texrunner.checkdriver".checkdriver
 local shellutil                    = require "texrunner.shellutil"
 local options                      = require "texrunner.option_type" -- legacy import
 local message                      = require "texrunner.message"
@@ -116,6 +115,21 @@ local function hooks_apply_suggestion_file_based(hooks: {number: {(function(comm
 				message.diag(hook[2])
 				hook[3] = true
 			end
+		end
+	end
+end
+
+local function hooks_apply_post_compile(hooks: {number: {(function(option_t.Options, option_t.PostCompileArgs)), string}}, options: option_t.Options, args: option_t.PostCompileArgs)
+	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
+	for _, prio in ipairs(sorted_prios) do
+		local hook = hooks[prio]
+		local valid, err = hooks_validate(hook)
+		if not valid then
+			error("Invalid hook: " .. err)
+		end
+		hook[1](options, args)
+		 if CLUTTEALTEX_VERBOSITY >= 1 then
+			message.info("Executing post_compile hook '", hook[2], "'")
 		end
 	end
 end

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -119,6 +119,20 @@ local function hooks_apply_suggestion_file_based(hooks: {number: {(function(comm
 	end
 end
 
+local function hooks_apply_suggestion_excelog_based(hooks: {number: {(function(string, option_t.Options):boolean), string}}, execlog: string, o:option_t.Options)
+	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
+	for _, prio in ipairs(sorted_prios) do
+		local hook = hooks[prio]
+		local valid, err = hooks_validate(hook)
+		if not valid then
+			error("Invalid hook: " .. err)
+		end
+		if hook[1](execlog, o) then
+			message.diag(hook[2])
+		end
+	end
+end
+
 local function hooks_apply_post_compile(hooks: {number: {(function(option_t.Options, option_t.PostCompileArgs)), string}}, options: option_t.Options, args: option_t.PostCompileArgs)
 	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
 	for _, prio in ipairs(sorted_prios) do
@@ -240,40 +254,7 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 		original_wd              = args.original_wd,
 	})
 
-	if not args.options.makeindex then
-		-- Check log file
-		if string.find(execlog, "No file [^\n]+%.ind%.") then
-			message.diag("You may want to use --makeindex option.")
-		end
-	end
-
-	if args.options.glossaries then
-	end
-
-	if args.options.bibtex then
-	elseif args.options.biber then
-	else
-		-- Check log file
-		if string.find(execlog, "No file [^\n]+%.bbl%.") then
-			message.diag("You may want to use --bibtex or --biber option.")
-		end
-	end
-
-	if args.options.memoize then
-	else
-		-- Check log file
-		if string.find(execlog, "Package memoize Warning") then
-			message.diag("You may want to use --memoize option.")
-		end
-	end
-
-	if args.options.sagetex then
-	else
-		-- Check log file
-		if string.find(execlog, "Run Sage on") then
-			message.diag("You may want to use --sagetex option.")
-		end
-	end
+	hooks_apply_suggestion_excelog_based(args.options.hooks.suggestion_execlog_based, execlog, args.options)
 
 	if string.find(execlog, "No pages of output.") then
 		return "No pages of output."

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -271,31 +271,6 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 	end
 
 	if args.options.bibtex then
-		local biblines2 = extract_bibtex_from_aux_file(mainauxfile, args.options.output_directory)
-		local bibtex_aux_hash2: string
-		if #biblines2 > 0 then
-			bibtex_aux_hash2 = md5.sum(table.concat(biblines2, "\n"))
-		end
-		local output_bbl = args.path_in_output_directory("bbl")
-		if bibtex_aux_hash ~= bibtex_aux_hash2 or reruncheck.comparefiletime(pathutil.abspath(mainauxfile), output_bbl, args.auxstatus) then
-			-- The input for BibTeX command has changed...
-			-- os.execute("pwd")
-			-- os.execute("echo $BIBINPUTS")
-			local bibtex_command = {
-				"cd", shellutil.escape(args.options.output_directory), "&&",
-				args.options.bibtex,
-				pathutil.basename(mainauxfile)
-			}
-			coroutine.yield(table.concat(bibtex_command, " "))
-		else
-			if CLUTTEALTEX_VERBOSITY >= 1 then
-				message.info("No need to run BibTeX.")
-			end
-			local succ, err = filesys.touch(output_bbl)
-			if not succ then
-				message.warn("Failed to touch " .. output_bbl .. " (" .. err .. ")")
-			end
-		end
 	elseif args.options.biber then
 		for _,file in ipairs(filelist) do
 			-- usual compilation with biber

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -163,12 +163,6 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 	-- run tex_injection hooks
 	tex_injection = hooks_apply_tex_injection(args.options.hooks.tex_injection, args.options, tex_injection)
 
-	if args.options.memoize then
-		tex_injection = string.format("%s\\PassOptionsToPackage{no memo dir,extract=no}{memoize}", tex_injection or "")
-	end
-	if args.options.memoize_opts then
-		tex_injection = string.format("%s\\PassOptionsToPackage{%s}{memoize}", tex_injection or "", table.concat(args.options.memoize_opts, ","))
-	end
 	if args.options.quiet then
 		if args.options.quiet >= 1 then
 			tex_injection = string.format("%s\\AddToHook{begindocument/end}[quietX]{\\hbadness=99999 \\hfuzz=9999pt}", tex_injection or "")

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -79,7 +79,7 @@ local function hooks_validate(hook: {function, string, boolean}): boolean, strin
 end
 
 -- returns the new tex_injection string
-local function hooks_apply_tex_injection(hooks: {number: {(function(option_t.Options, engine_t.Option, string):string), string}}, options: option_t.Options, tex_options: engine_t.Option, tex_injection:string): string
+local function hooks_apply_tex_injection(hooks: {number: {option_t.Hooks.tex_injection_func, string}}, options: option_t.Options, tex_options: engine_t.Option, tex_injection:string): string
 	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
 	local result = tex_injection
 	for _, prio in ipairs(sorted_prios) do
@@ -96,7 +96,7 @@ local function hooks_apply_tex_injection(hooks: {number: {(function(option_t.Opt
 	return result
 end
 
-local function hooks_apply_suggestion_file_based(hooks: {number: {(function(common_t.Filemap_ele):boolean), string, boolean}}, filelist:{common_t.Filemap_ele})
+local function hooks_apply_suggestion_file_based(hooks: {number: {option_t.Hooks.suggestion_file_based_func, string, boolean}}, filelist:{common_t.Filemap_ele})
 	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
 	-- check if all hooks are valid
 	for _, prio in ipairs(sorted_prios) do
@@ -119,7 +119,7 @@ local function hooks_apply_suggestion_file_based(hooks: {number: {(function(comm
 	end
 end
 
-local function hooks_apply_suggestion_excelog_based(hooks: {number: {(function(string, option_t.Options):boolean), string}}, execlog: string, o:option_t.Options)
+local function hooks_apply_suggestion_excelog_based(hooks: {number: {option_t.Hooks.suggestion_execlog_based_func, string}}, execlog: string, o:option_t.Options)
 	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
 	for _, prio in ipairs(sorted_prios) do
 		local hook = hooks[prio]
@@ -133,7 +133,7 @@ local function hooks_apply_suggestion_excelog_based(hooks: {number: {(function(s
 	end
 end
 
-local function hooks_apply_post_compile(hooks: {number: {(function(option_t.Options, option_t.PostCompileArgs)), string}}, options: option_t.Options, args: option_t.PostCompileArgs)
+local function hooks_apply_post_compile(hooks: {number: {option_t.Hooks.post_compile_func, string}}, options: option_t.Options, args: option_t.PostCompileArgs)
 	local sorted_prios = hooks_sort_prios(hooks as {number: {function, string}})
 	for _, prio in ipairs(sorted_prios) do
 		local hook = hooks[prio]

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -36,6 +36,7 @@ local safename                     = require "texrunner.safename"
 local recoverylib                  = require "texrunner.recovery"
 
 local option_t                     = require "texrunner.option_type"
+local common_t                     = require "texrunner.common_types"
 
 local exit: function(code:integer)
 global CLUTTEALTEX_TEST_ENV: boolean
@@ -46,7 +47,7 @@ else
 end
 
 local record Module
-	get_typesetter: function(args: Module.typesetArgs): (function(): boolean, string, integer, {reruncheck.Filemap_ele})
+	get_typesetter: function(args: Module.typesetArgs): (function(): boolean, string, integer, {common_t.Filemap_ele})
 	record typesetArgs
 		auxstatus:{string:reruncheck.Status}
 		iteration:integer
@@ -552,9 +553,9 @@ local function do_typeset(args: Module.typesetArgs): boolean, string, integer
 	return true
 end
 
-local function get_typesetter(args: Module.typesetArgs): (function(): boolean, string, integer, {reruncheck.Filemap_ele})
-	local filelist, filemap: {reruncheck.Filemap_ele}, {string: reruncheck.Filemap_ele}
-	return function(): boolean, string, integer, {reruncheck.Filemap_ele}
+local function get_typesetter(args: Module.typesetArgs): (function(): boolean, string, integer, {common_t.Filemap_ele})
+	local filelist, filemap: {common_t.Filemap_ele}, {string: common_t.Filemap_ele}
+	return function(): boolean, string, integer, {common_t.Filemap_ele}
 		local success, termination, status = do_typeset(args)
 		-- TODO: filenames here can be UTF-8 if command_line_encoding=utf-8
 

--- a/src_teal/texrunner/typeset.tl
+++ b/src_teal/texrunner/typeset.tl
@@ -105,8 +105,26 @@ local function single_run_coroutine(args: Module.typesetArgs): boolean|string
 
 	local tex_injection = args.tex_options.tex_injection or ""
 
-	if args.options.includeonly then
-		tex_injection = string.format("%s\\includeonly{%s}", args.tex_options.tex_injection or "", args.options.includeonly)
+	-- collect hook priorities
+	local hook_prios = {}
+	for prio in pairs(args.options.hooks.tex_injection) do
+		table.insert(hook_prios, prio)
+	end
+	-- sort the priorities in order to execute them in the right order
+	table.sort(hook_prios)
+	for _,prio in ipairs(hook_prios) do
+		local h = args.options.hooks.tex_injection[prio]
+		-- check if hook is valid
+		if not h or not h[1] or not h[2] then
+			message.error("Malformed hook: h[1]: ", h[1], " h[2]: ", h[2])
+			exit(1)
+		else
+			-- execute hook
+			if CLUTTEALTEX_VERBOSITY >= 1 then
+				message.info("Executing tex_injection hook '", h[2], "'")
+			end
+			tex_injection = h[1](args.options, tex_injection)
+		end
 	end
 
 	if minted or args.options.package_support["minted"] then

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -212,6 +212,34 @@ local function biber(options:option_t.Options, args:option_t.PostCompileArgs)
 	end
 end
 
+local function memoize_run(options:option_t.Options, args:option_t.PostCompileArgs)
+	for _,file in ipairs(args.filelist) do
+		-- usual compilation with memoize
+		-- tex      -> pdflatex tex    -> aux,pdf,mmz
+		-- mmz,pdf  -> memoize-extract -> pdf,pdf
+		-- tex      -> pdflatex tex    -> aux,pdf
+		if pathutil.ext(file.path) == "mmz" then
+			local must_extract = false
+			for l in io.lines(file.abspath) do
+				local newExtern = string.match(l, "^\\mmzNewExtern")
+				must_extract = must_extract or newExtern ~= nil
+			end
+			if must_extract then
+				local extract_command = {
+					options.memoize, -- Do not escape options.memoize to allow additional options
+					pathutil.basename(pathutil.replaceext(file.abspath, "tex"))
+				}
+				coroutine.yield(table.concat(extract_command, " "))
+				-- ensure document gets recompiled afterwards
+				local succ, err = filesys.touch(file.path)
+				if not succ then
+					message.warn("Failed to touch " .. file.path .. " (" .. err .. ")")
+				end
+			end
+		end
+	end
+end
+
 local function sagetex(options:option_t.Options, args:option_t.PostCompileArgs)
 	for _,file in ipairs(args.filelist) do
 		-- usual compilation with sagetex
@@ -254,5 +282,6 @@ return {
 	glossaries  = glossaries,
 	bibtex      = bibtex,
 	biber       = biber,
+	memoize_run = memoize_run,
 	sagetex     = sagetex,
 }

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -188,6 +188,33 @@ local function biber(options:option_t.Options, args:option_t.PostCompileArgs)
 	end
 end
 
+local function sagetex(options:option_t.Options, args:option_t.PostCompileArgs)
+	for _,file in ipairs(args.filelist) do
+		-- usual compilation with sagetex
+		-- tex      -> pdflatex tex -> aux,pdf,sage
+		-- sage     -> sage sage    -> sout (eps)
+		-- tex,sout -> pdflatex tex -> aux,pdf,sage
+		local output_sout = pathutil.replaceext(file.abspath, "sout")
+		if pathutil.ext(file.path) == "sage" then
+			local sagefileinfo = {path = file.path, abspath = file.abspath, kind = "auxiliary"}
+			if reruncheck.comparefileinfo({sagefileinfo}, args.auxstatus) then
+				local sage_command = {
+					options.sagetex, -- Do not escape options.sagetex to allow additional options
+					pathutil.basename(file.abspath)
+				}
+				coroutine.yield(table.concat(sage_command, " "))
+				-- watch for changes in .sage
+				table.insert(args.filelist, {path = output_sout, abspath = output_sout, kind = "auxiliary"})
+			else
+				local succ, err = filesys.touch(output_sout)
+				if not succ then
+					message.warn("Failed to touch " .. output_sout .. " (" .. err .. ")")
+				end
+			end
+		end
+	end
+end
+
 return {
 	includeonly  = includeonly,
 	memoize      = memoize,
@@ -202,4 +229,5 @@ return {
 	makeindex   = makeindex,
 	bibtex      = bibtex,
 	biber       = biber,
+	sagetex     = sagetex,
 }

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -110,6 +110,35 @@ local function makeindex(options:option_t.Options, args:option_t.PostCompileArgs
 	end
 end
 
+local function bibtex(options:option_t.Options, args:option_t.PostCompileArgs)
+	local mainauxfile = args.path_in_output_directory("aux")
+	local biblines2 = extract_bibtex_from_aux_file(mainauxfile, options.output_directory)
+	local bibtex_aux_hash2: string
+	if #biblines2 > 0 then
+		bibtex_aux_hash2 = md5.sum(table.concat(biblines2, "\n"))
+	end
+	local output_bbl = args.path_in_output_directory("bbl")
+	if args.bibtex_aux_hash ~= bibtex_aux_hash2 or reruncheck.comparefiletime(pathutil.abspath(mainauxfile), output_bbl, args.auxstatus) then
+		-- The input for BibTeX command has changed...
+		-- os.execute("pwd")
+		-- os.execute("echo $BIBINPUTS")
+		local bibtex_command = {
+			"cd", shellutil.escape(options.output_directory), "&&",
+			options.bibtex,
+			pathutil.basename(mainauxfile)
+		}
+		coroutine.yield(table.concat(bibtex_command, " "))
+	else
+		if CLUTTEALTEX_VERBOSITY >= 1 then
+			message.info("No need to run BibTeX.")
+		end
+		local succ, err = filesys.touch(output_bbl)
+		if not succ then
+			message.warn("Failed to touch " .. output_bbl .. " (" .. err .. ")")
+		end
+	end
+end
+
 return {
 	includeonly  = includeonly,
 	memoize      = memoize,
@@ -122,4 +151,5 @@ return {
 	check_driver = check_driver,
 
 	makeindex   = makeindex,
+	bibtex      = bibtex,
 }

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -26,6 +26,14 @@ local function includeonly(options:option_t.Options, tex_injection: string): str
 	return string.format("%s\\includeonly{%s}", tex_injection or "", options.includeonly)
 end
 
+local function memoize(options:option_t.Options, tex_injection: string): string
+	return string.format("%s\\PassOptionsToPackage{no memo dir,extract=no}{memoize}", tex_injection or "")
+end
+
+local function memoize_opts(options:option_t.Options, tex_injection: string): string
+	return string.format("%s\\PassOptionsToPackage{%s}{memoize}", tex_injection or "", table.concat(options.memoize_opts, ","))
+end
+
 local function ps_minted(options:option_t.Options, tex_injection: string): string
 	local outdir = options.output_directory
 	if os.type == "windows" then
@@ -48,7 +56,9 @@ local function ps_epstopdf(options:option_t.Options, tex_injection: string): str
 end
 
 return {
-	includeonly = includeonly,
-	ps_minted   = ps_minted,
-	ps_epstopdf = ps_epstopdf,
+	includeonly  = includeonly,
+	ps_minted    = ps_minted,
+	ps_epstopdf  = ps_epstopdf,
+	memoize      = memoize,
+	memoize_opts = memoize_opts,
 }

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -1,0 +1,31 @@
+--[[
+Copyright 2016 ARATA Mizuki
+Copyright 2024 Lukas Heindl
+
+This file is part of CluttealTeX.
+
+CluttealTeX is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+CluttealTeX is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
+]]
+
+local option_t = require "texrunner.option_type"
+
+local function includeonly(options:option_t.Options, tex_injection: string): string
+	return string.format("%s\\includeonly{%s}", tex_injection or "", options.includeonly)
+end
+
+
+
+return {
+	includeonly = includeonly,
+}

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -18,10 +18,21 @@ You should have received a copy of the GNU General Public License
 along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
-local os = require"os_"
+local os      = require"os_"
+local filesys = require "lfs"
+local md5     = require "md5"
 
 local option_t = require "texrunner.option_type"
+local common_t = require "texrunner.common_types"
 local engine_t = require "texrunner.tex_engine"
+
+local message    = require "texrunner.message"
+local pathutil   = require "texrunner.pathutil"
+local shellutil  = require "texrunner.shellutil"
+local reruncheck = require "texrunner.reruncheck"
+local extract_bibtex_from_aux_file = require "texrunner.auxfile".extract_bibtex_from_aux_file
+
+local checkdriver                  = require "texrunner.checkdriver".checkdriver
 
 local function includeonly(options:option_t.Options, tex_options:engine_t.Option, tex_injection: string): string
 	return string.format("%s\\includeonly{%s}", tex_injection or "", options.includeonly)
@@ -67,6 +78,34 @@ local function ps_epstopdf(options:option_t.Options, tex_options:engine_t.Option
 	return string.format("%s\\PassOptionsToPackage{outdir=%s}{epstopdf}", tex_injection or "", outdir)
 end
 
+-- needs to run in a coroutine => will yield commands that should be executed
+local function makeindex(options:option_t.Options, args:option_t.PostCompileArgs)
+	-- Look for .idx files and run MakeIndex
+	for _,file in ipairs(args.filelist) do
+		if pathutil.ext(file.path) == "idx" then
+			-- Run makeindex if the .idx file is new or updated
+			local idxfileinfo = {path = file.path, abspath = file.abspath, kind = "auxiliary"}
+			local output_ind = pathutil.replaceext(file.abspath, "ind")
+			if reruncheck.comparefileinfo({idxfileinfo}, args.auxstatus) or reruncheck.comparefiletime(file.abspath, output_ind, args.auxstatus) then
+				local idx_dir = pathutil.dirname(file.abspath)
+				local makeindex_command = {
+					"cd", shellutil.escape(idx_dir), "&&",
+					options.makeindex, -- Do not escape options.makeindex to allow additional options
+					"-o", pathutil.basename(output_ind),
+					pathutil.basename(file.abspath)
+				}
+				coroutine.yield(table.concat(makeindex_command, " "))
+				table.insert(args.filelist, {path = output_ind, abspath = output_ind, kind = "auxiliary"})
+			else
+				local succ, err = filesys.touch(output_ind)
+				if not succ then
+					message.warn("Failed to touch " .. output_ind .. " (" .. err .. ")")
+				end
+			end
+		end
+	end
+end
+
 return {
 	includeonly  = includeonly,
 	ps_minted    = ps_minted,
@@ -74,4 +113,5 @@ return {
 	memoize      = memoize,
 	memoize_opts = memoize_opts,
 	quiet        = quiet,
+	makeindex   = makeindex,
 }

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -267,21 +267,145 @@ local function sagetex(options:option_t.Options, args:option_t.PostCompileArgs)
 	end
 end
 
+-- generic hook function to get a sorted list of priorities
+local function sort_prios(hook_table: {number: {function, string}}): {number}
+	local priorities = {}
+	for prio in pairs(hook_table) do
+		table.insert(priorities, prio)
+	end
+	table.sort(priorities)
+	return priorities
+end
+
+-- generic hook function to check if a hook-tuple is valid
+local function validate(hook: {function, string, boolean}): boolean, string
+	if not hook or not hook[1] or not hook[2] then
+		return false, "Malformed hook"
+	end
+	return true, nil
+end
+
+-- returns the new tex_injection string
+local function apply_tex_injection(hooks: {number: {option_t.Hooks.tex_injection_func, string}}, options: option_t.Options, tex_options: engine_t.Option, tex_injection:string): string
+	local sorted_prios = sort_prios(hooks as {number: {function, string}})
+	local result = tex_injection
+	for _, prio in ipairs(sorted_prios) do
+		local hook = hooks[prio]
+		local valid, err = validate(hook)
+		if not valid then
+			error("Invalid hook: " .. err)
+		end
+		 if CLUTTEALTEX_VERBOSITY >= 1 then
+			message.info("Executing tex_injection hook '", hook[2], "'")
+		end
+		result = hook[1](options, tex_options, result)
+	end
+	return result
+end
+
+-- only does message.diag, no modifications, no return
+local function apply_suggestion_file_based(hooks: {number: {option_t.Hooks.suggestion_file_based_func, string, boolean}}, filelist:{common_t.Filemap_ele})
+	local sorted_prios = sort_prios(hooks as {number: {function, string}})
+	-- check if all hooks are valid
+	for _, prio in ipairs(sorted_prios) do
+		local hook = hooks[prio]
+		local valid, err = validate(hook)
+		if not valid then
+			error("Invalid hook: " .. err)
+		end
+	end
+
+	-- run hooks on files contained in the filelist and emit messages
+	for _,fileinfo in ipairs(filelist) do
+		for _, prio in ipairs(sorted_prios) do
+			local hook = hooks[prio]
+			if not hook[3] and hook[1](fileinfo) then
+				message.diag(hook[2])
+				hook[3] = true
+			end
+		end
+	end
+end
+
+-- only does message.diag, no modifications, no return
+local function apply_suggestion_excelog_based(hooks: {number: {option_t.Hooks.suggestion_execlog_based_func, string}}, execlog: string, o:option_t.Options)
+	local sorted_prios = sort_prios(hooks as {number: {function, string}})
+	for _, prio in ipairs(sorted_prios) do
+		local hook = hooks[prio]
+		local valid, err = validate(hook)
+		if not valid then
+			error("Invalid hook: " .. err)
+		end
+		if hook[1](execlog, o) then
+			message.diag(hook[2])
+		end
+	end
+end
+
+-- must run in the coroutine
+-- yields shell commands to be executed
+local function apply_post_compile(hooks: {number: {option_t.Hooks.post_compile_func, string}}, options: option_t.Options, args: option_t.PostCompileArgs)
+	local sorted_prios = sort_prios(hooks as {number: {function, string}})
+	for _, prio in ipairs(sorted_prios) do
+		local hook = hooks[prio]
+		local valid, err = validate(hook)
+		if not valid then
+			error("Invalid hook: " .. err)
+		end
+		 if CLUTTEALTEX_VERBOSITY >= 1 then
+			message.info("Executing post_compile hook '", hook[2], "'")
+		end
+		hook[1](options, args)
+	end
+end
+
+-- must run in the coroutine
+-- yields shell commands to be executed
+local function apply_post_build(hooks: {number: {option_t.Hooks.post_build_func, string}}, options: option_t.Options)
+	local sorted_prios = sort_prios(hooks as {number: {function, string}})
+	for _, prio in ipairs(sorted_prios) do
+		local hook = hooks[prio]
+		local valid, err = validate(hook)
+		if not valid then
+			error("Invalid hook: " .. err)
+		end
+		 if CLUTTEALTEX_VERBOSITY >= 1 then
+			message.info("Executing post_build hook '", hook[2], "'")
+		end
+		hook[1](options)
+	end
+end
+
 return {
+	-- tex_injection hooks
 	includeonly  = includeonly,
 	memoize      = memoize,
 	memoize_opts = memoize_opts,
 	quiet        = quiet,
 
+	-- suggestion_file_based hooks
 	ps_minted    = ps_minted,
 	ps_epstopdf  = ps_epstopdf,
 
+	-- hook
 	check_driver = check_driver,
 
+	-- post_compile hooks
 	makeindex   = makeindex,
 	glossaries  = glossaries,
 	bibtex      = bibtex,
 	biber       = biber,
 	memoize_run = memoize_run,
 	sagetex     = sagetex,
+
+	-- functions for hook management
+	apply_post_compile             = apply_post_compile,
+	apply_tex_injection            = apply_tex_injection,
+	apply_suggestion_file_based    = apply_suggestion_file_based,
+	apply_suggestion_excelog_based = apply_suggestion_excelog_based,
+	apply_post_build               = apply_post_build,
+
+	-- internal
+	sort_prios = sort_prios,
+	validate   = validate,
 }

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -78,6 +78,10 @@ local function ps_epstopdf(options:option_t.Options, tex_options:engine_t.Option
 	return string.format("%s\\PassOptionsToPackage{outdir=%s}{epstopdf}", tex_injection or "", outdir)
 end
 
+local function check_driver(options:option_t.Options, args:option_t.PostCompileArgs)
+	checkdriver(options.check_driver, args.filelist)
+end
+
 -- needs to run in a coroutine => will yield commands that should be executed
 local function makeindex(options:option_t.Options, args:option_t.PostCompileArgs)
 	-- Look for .idx files and run MakeIndex
@@ -108,10 +112,14 @@ end
 
 return {
 	includeonly  = includeonly,
-	ps_minted    = ps_minted,
-	ps_epstopdf  = ps_epstopdf,
 	memoize      = memoize,
 	memoize_opts = memoize_opts,
 	quiet        = quiet,
+
+	ps_minted    = ps_minted,
+	ps_epstopdf  = ps_epstopdf,
+
+	check_driver = check_driver,
+
 	makeindex   = makeindex,
 }

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -35,6 +35,17 @@ local function memoize_opts(options:option_t.Options, tex_options:engine_t.Optio
 	return string.format("%s\\PassOptionsToPackage{%s}{memoize}", tex_injection or "", table.concat(options.memoize_opts, ","))
 end
 
+local function quiet(options:option_t.Options, tex_options:engine_t.Option, tex_injection: string): string
+	if options.quiet >= 1 then
+		tex_injection = string.format("%s\\AddToHook{begindocument/end}[quietX]{\\hbadness=99999 \\hfuzz=9999pt}", tex_injection or "")
+	end
+	if options.quiet >= 2 then
+		tex_options.interaction = "batchmode"
+		tex_injection = string.format("%s\\AddToHook{begindocument/end}[quiet]{\\nonstopmode}\\AddToHook{enddocument/info}[quiet]{\\batchmode}", tex_injection or "")
+	end
+	return tex_injection
+end
+
 local function ps_minted(options:option_t.Options, tex_options:engine_t.Option, tex_injection: string): string
 	local outdir = options.output_directory
 	if os.type == "windows" then
@@ -62,4 +73,5 @@ return {
 	ps_epstopdf  = ps_epstopdf,
 	memoize      = memoize,
 	memoize_opts = memoize_opts,
+	quiet        = quiet,
 }

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -139,6 +139,55 @@ local function bibtex(options:option_t.Options, args:option_t.PostCompileArgs)
 	end
 end
 
+local function biber(options:option_t.Options, args:option_t.PostCompileArgs)
+	local mainauxfile = args.path_in_output_directory("aux")
+	for _,file in ipairs(args.filelist) do
+		-- usual compilation with biber
+		-- tex     -> pdflatex tex -> aux,bcf,pdf,run.xml
+		-- bcf     -> biber bcf    -> bbl
+		-- tex,bbl -> pdflatex tex -> aux,bcf,pdf,run.xml
+		if pathutil.ext(file.path) == "bcf" then
+			-- Run biber if the .bcf file is new or updated
+			local bcffileinfo = {path = file.path, abspath = file.abspath, kind = "auxiliary"}
+			local output_bbl = pathutil.replaceext(file.abspath, "bbl")
+			local updated_dot_bib = false
+			-- get the .bib files, the bcf uses as input
+			for l in io.lines(file.abspath) do
+				local bib = string.match(l, "<bcf:datasource .*>(.*)</bcf:datasource>") -- might be unstable if biblatex adds e.g. a linebreak
+				if bib then
+					local bibfile = pathutil.join(args.original_wd, bib)
+					local succ, err = io.open(bibfile, "r") -- check if file is present, don't use touch to avoid triggering a rerun
+					if succ then
+						succ:close()
+						local updated_dot_bib_tmp = not reruncheck.comparefiletime(pathutil.abspath(mainauxfile), bibfile, args.auxstatus)
+						if updated_dot_bib_tmp then
+							message.info(bibfile.." is newer than aux")
+						end
+						updated_dot_bib = updated_dot_bib_tmp or updated_dot_bib
+					else
+						message.warn(bibfile .. " is not accessible (" .. err .. ")")
+					end
+				end
+			end
+			if updated_dot_bib or reruncheck.comparefileinfo({bcffileinfo}, args.auxstatus) or reruncheck.comparefiletime(file.abspath, output_bbl, args.auxstatus) then
+				local biber_command = {
+					options.biber, -- Do not escape options.biber to allow additional options
+					"--output-directory", shellutil.escape(options.output_directory),
+					pathutil.basename(file.abspath)
+				}
+				coroutine.yield(table.concat(biber_command, " "))
+				-- watch for changes in the bbl
+				table.insert(args.filelist, {path = output_bbl, abspath = output_bbl, kind = "auxiliary"})
+			else
+				local succ, err = filesys.touch(output_bbl)
+				if not succ then
+					message.warn("Failed to touch " .. output_bbl .. " (" .. err .. ")")
+				end
+			end
+		end
+	end
+end
+
 return {
 	includeonly  = includeonly,
 	memoize      = memoize,
@@ -152,4 +201,5 @@ return {
 
 	makeindex   = makeindex,
 	bibtex      = bibtex,
+	biber       = biber,
 }

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -18,14 +18,37 @@ You should have received a copy of the GNU General Public License
 along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
+local os = require"os_"
+
 local option_t = require "texrunner.option_type"
 
 local function includeonly(options:option_t.Options, tex_injection: string): string
 	return string.format("%s\\includeonly{%s}", tex_injection or "", options.includeonly)
 end
 
+local function ps_minted(options:option_t.Options, tex_injection: string): string
+	local outdir = options.output_directory
+	if os.type == "windows" then
+		outdir = string.gsub(outdir, "\\", "/") -- Use forward slashes
+	end
 
+	return string.format("%s\\PassOptionsToPackage{outputdir=%s}{minted}", tex_injection or "", outdir)
+end
+
+local function ps_epstopdf(options:option_t.Options, tex_injection: string): string
+	local outdir = options.output_directory
+	if os.type == "windows" then
+		outdir = string.gsub(outdir, "\\", "/") -- Use forward slashes
+	end
+	if string.sub(outdir, -1, -1) ~= "/" then
+		outdir = outdir.."/" -- Must end with a directory separator
+	end
+
+	return string.format("%s\\PassOptionsToPackage{outdir=%s}{epstopdf}", tex_injection or "", outdir)
+end
 
 return {
 	includeonly = includeonly,
+	ps_minted   = ps_minted,
+	ps_epstopdf = ps_epstopdf,
 }

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -110,6 +110,30 @@ local function makeindex(options:option_t.Options, args:option_t.PostCompileArgs
 	end
 end
 
+local function glossaries(options:option_t.Options, args:option_t.PostCompileArgs)
+	-- Look for configured files and run makeindex/xindy
+	for _,file in ipairs(args.filelist) do
+		for _, cfg in ipairs(options.glossaries) do
+			if pathutil.ext(file.path) == cfg.inp then
+				-- Run xindy/makeindex if the specified input-file is new or updated
+				local inputfileinfo = {path = file.path, abspath = file.abspath, kind = "auxiliary"}
+				local outputfile = args.path_in_output_directory(cfg.out)
+				if reruncheck.comparefileinfo({inputfileinfo}, args.auxstatus) or reruncheck.comparefiletime(file.abspath, outputfile, args.auxstatus) then
+					-- TODO remove print statement?
+					print(cfg.cmd(args.path_in_output_directory))
+					coroutine.yield(cfg.cmd(args.path_in_output_directory))
+					table.insert(args.filelist, {path = outputfile, abspath = outputfile, kind = "auxiliary"})
+				else
+					local succ, err = filesys.touch(outputfile)
+					if not succ then
+						message.warn("Failed to touch " .. outputfile .. " (" .. err .. ")")
+					end
+				end
+			end
+		end
+	end
+end
+
 local function bibtex(options:option_t.Options, args:option_t.PostCompileArgs)
 	local mainauxfile = args.path_in_output_directory("aux")
 	local biblines2 = extract_bibtex_from_aux_file(mainauxfile, options.output_directory)
@@ -227,6 +251,7 @@ return {
 	check_driver = check_driver,
 
 	makeindex   = makeindex,
+	glossaries  = glossaries,
 	bibtex      = bibtex,
 	biber       = biber,
 	sagetex     = sagetex,

--- a/src_teal/texrunner/typeset_hooks.tl
+++ b/src_teal/texrunner/typeset_hooks.tl
@@ -21,20 +21,21 @@ along with CluttealTeX.  If not, see <http://www.gnu.org/licenses/>.
 local os = require"os_"
 
 local option_t = require "texrunner.option_type"
+local engine_t = require "texrunner.tex_engine"
 
-local function includeonly(options:option_t.Options, tex_injection: string): string
+local function includeonly(options:option_t.Options, tex_options:engine_t.Option, tex_injection: string): string
 	return string.format("%s\\includeonly{%s}", tex_injection or "", options.includeonly)
 end
 
-local function memoize(options:option_t.Options, tex_injection: string): string
+local function memoize(options:option_t.Options, tex_options:engine_t.Option, tex_injection: string): string
 	return string.format("%s\\PassOptionsToPackage{no memo dir,extract=no}{memoize}", tex_injection or "")
 end
 
-local function memoize_opts(options:option_t.Options, tex_injection: string): string
+local function memoize_opts(options:option_t.Options, tex_options:engine_t.Option, tex_injection: string): string
 	return string.format("%s\\PassOptionsToPackage{%s}{memoize}", tex_injection or "", table.concat(options.memoize_opts, ","))
 end
 
-local function ps_minted(options:option_t.Options, tex_injection: string): string
+local function ps_minted(options:option_t.Options, tex_options:engine_t.Option, tex_injection: string): string
 	local outdir = options.output_directory
 	if os.type == "windows" then
 		outdir = string.gsub(outdir, "\\", "/") -- Use forward slashes
@@ -43,7 +44,7 @@ local function ps_minted(options:option_t.Options, tex_injection: string): strin
 	return string.format("%s\\PassOptionsToPackage{outputdir=%s}{minted}", tex_injection or "", outdir)
 end
 
-local function ps_epstopdf(options:option_t.Options, tex_injection: string): string
+local function ps_epstopdf(options:option_t.Options, tex_options:engine_t.Option, tex_injection: string): string
 	local outdir = options.output_directory
 	if os.type == "windows" then
 		outdir = string.gsub(outdir, "\\", "/") -- Use forward slashes

--- a/src_teal/texrunner/watcher.tl
+++ b/src_teal/texrunner/watcher.tl
@@ -25,6 +25,7 @@ local options        = require "texrunner.option_type"
 local message        = require "texrunner.message"
 local reruncheck     = require "texrunner.reruncheck"
 local fswatcherlib_t = require"texrunner.fswatcher"
+local common_t       = require"texrunner.common_types"
 
 local exit: function(code:integer)
 global CLUTTEALTEX_TEST_ENV: boolean
@@ -35,7 +36,7 @@ else
 end
 
 -- Helper function to determine whether a file should be watched based on user-specified filters
-local function should_watch_file(fileinfo:reruncheck.Filemap_ele, filters: {options.WatchIncExc}): boolean
+local function should_watch_file(fileinfo:common_t.Filemap_ele, filters: {options.WatchIncExc}): boolean
 	if not filters then
 		-- If no filters are provided, watch all files by default
 		return true
@@ -69,7 +70,7 @@ local function should_watch_file(fileinfo:reruncheck.Filemap_ele, filters: {opti
 end
 
 -- Gather a list of input files to be watched based on filters and maximum allowed watches
-local function gather_input_files_to_watch(max_watches: integer, options: options.Options, filelist: {reruncheck.Filemap_ele}): {string}
+local function gather_input_files_to_watch(max_watches: integer, options: options.Options, filelist: {common_t.Filemap_ele}): {string}
 	local input_files_to_watch = {}
 	-- Iterate over the file list to determine files eligible for watching
 	for _,fileinfo in ipairs(filelist) do
@@ -207,7 +208,7 @@ end
 
 local record Module
 	get_do_watch: function(options: options.Options): ((function(files:{string}): boolean), integer)
-	gather_input_files_to_watch: function(max_watches: integer, options: options.Options, filelist: {reruncheck.Filemap_ele}): {string}
+	gather_input_files_to_watch: function(max_watches: integer, options: options.Options, filelist: {common_t.Filemap_ele}): {string}
 end
 
 local _M:Module = {

--- a/utils/build_cluttealtex.lua
+++ b/utils/build_cluttealtex.lua
@@ -125,6 +125,10 @@ local modules = {
 		path = "texrunner/typeset.lua",
 	},
 	{
+		name = "texrunner.typeset_hooks",
+		path = "texrunner/typeset_hooks.lua",
+	},
+	{
 		name = "texrunner.watcher",
 		path = "texrunner/watcher.lua",
 	},

--- a/utils/build_cluttealtex.lua
+++ b/utils/build_cluttealtex.lua
@@ -129,6 +129,10 @@ local modules = {
 		path = "texrunner/typeset_hooks.lua",
 	},
 	{
+		name = "texrunner.common_types",
+		path = "texrunner/common_types.lua",
+	},
+	{
 		name = "texrunner.watcher",
 		path = "texrunner/watcher.lua",
 	},


### PR DESCRIPTION
See #25

Todos:
- [x] `tex_injection`
    - [x] `includeonly`
    - [x] `package_support`
    - [x] `memoize`/`memoize_opts`
    - [x] `quiet`
- [x] `suggestion_file_based`
    - [x] `package_support`
- [x] ~`pre_compile`~
   - [x] ~`start_with_draft`~
- [x] `post_compile`
    - [x] `makeindex`
    - [x] `glossaries`
    - [x] `bibtex`
    - [x] `biber`
    - [x] `memoize`
    - [x] `sagetex`
- [x] `suggestion_log_based` (evaluating `execlog` after running *TeX)
    - [x] `makeindex`
    - [x] `glossaries`
    - [x] `bibtex`
    - [x] `biber`
    - [x] `memoize`
    - [x] `sagetex`
- [x] ~`pre_build`~
- [x] `post_build`

---

- [x] write tests

---
not quite satisfied with the names of the hooks. It's easy to mix up `build` and `compile`